### PR TITLE
Logs unrecognized highlight names

### DIFF
--- a/Example/Example/Library/HighlightName.swift
+++ b/Example/Example/Library/HighlightName.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if DEBUG
+private var previousUnrecognizedHighlightNames: [String] = []
+#endif
+
 enum HighlightName: String {
     case comment
     case function
@@ -21,6 +25,14 @@ enum HighlightName: String {
             }
             comps.removeLast()
         }
+#if DEBUG
+        if !previousUnrecognizedHighlightNames.contains(rawHighlightName) {
+            previousUnrecognizedHighlightNames.append(rawHighlightName)
+            print("Unrecognized highlight name: '\(rawHighlightName)'."
+                  + " Add the highlight name to HighlightName.swift if you want to add support for syntax highlighting it."
+                  + " This message will only be shown once per highlight name.")
+        }
+#endif
         return nil
     }
 }


### PR DESCRIPTION
The encountering a raw highlight name that could not be mapped to a HighlightName, a message will be printed in the log. This PR is a response to #7.