### PR TITLE
No longer applies captures with unsupported predicates

### DIFF
--- a/Sources/Runestone/Language/Internal/TreeSitter/TreeSitterTextPredicatesEvaluator.swift
+++ b/Sources/Runestone/Language/Internal/TreeSitter/TreeSitterTextPredicatesEvaluator.swift
@@ -3,6 +3,9 @@ import Foundation
 final class TreeSitterTextPredicatesEvaluator {
     private let match: TreeSitterQueryMatch
     private let stringView: StringView
+#if DEBUG
+    static var previousUnsupportedPredicateNames: [String] = []
+#endif
 
     init(match: TreeSitterQueryMatch, stringView: StringView) {
         self.match = match
@@ -27,6 +30,14 @@ final class TreeSitterTextPredicatesEvaluator {
                 if !evaluate(using: parameters) {
                     return false
                 }
+            case .unsupported(let parameters):
+                #if DEBUG
+                if !Self.previousUnsupportedPredicateNames.contains(parameters.name) {
+                    Self.previousUnsupportedPredicateNames.append(parameters.name)
+                    print("Unsupported predicate '\(parameters.name)'. This message is only printed once and only when running in the debug configuration.")
+                }
+                #endif
+                return false
             }
         }
         return true

--- a/Sources/Runestone/TreeSitter/TreeSitterPredicateMapper.swift
+++ b/Sources/Runestone/TreeSitter/TreeSitterPredicateMapper.swift
@@ -23,6 +23,8 @@ enum TreeSitterPredicateMapper {
             case "not-match?":
                 textPredicates.append(textPredicate(fromMatchSteps: predicate.steps, isPositive: false))
             default:
+                let parameters = TreeSitterTextPredicate.UnsupportedParameters(name: predicate.name)
+                textPredicates.append(.unsupported(parameters))
                 break
             }
         }

--- a/Sources/Runestone/TreeSitter/TreeSitterTextPredicate.swift
+++ b/Sources/Runestone/TreeSitter/TreeSitterTextPredicate.swift
@@ -37,9 +37,18 @@ enum TreeSitterTextPredicate {
         }
     }
 
+    struct UnsupportedParameters {
+        let name: String
+
+        init(name: String) {
+            self.name = name
+        }
+    }
+
     case captureEqualsString(CaptureEqualsStringParameters)
     case captureEqualsCapture(CaptureEqualsCaptureParameters)
     case captureMatchesPattern(CaptureMatchesPatternParameters)
+    case unsupported(UnsupportedParameters)
 }
 
 extension TreeSitterTextPredicate.CaptureEqualsStringParameters: CustomDebugStringConvertible {


### PR DESCRIPTION
This PR fixes an issue where Runestone would always apply captures that had an unsupported predicate.

This issue became very apparent when adding support for the Lua language which has a query with a predicate named `lua-match`. At this point I do not want to introduce language specific code in Runestone, and as such, this predicate is not supported.

It seems that the best behavior is to ignore captures with unsupported text predicates. That means applying too few captures rather than too many and incorrectly highlighting some text.