### PR TITLE
Uses line break instead of cluster break

### DIFF
--- a/Sources/Runestone/TextView/LineController/LineTypesetter.swift
+++ b/Sources/Runestone/TextView/LineController/LineTypesetter.swift
@@ -169,7 +169,7 @@ private extension LineTypesetter {
     }
 
     private func suggestNextLineBreak(using typesetter: CTTypesetter) -> Int {
-        let length = CTTypesetterSuggestClusterBreak(typesetter, startOffset, Double(constrainingWidth))
+        let length = CTTypesetterSuggestLineBreak(typesetter, startOffset, Double(constrainingWidth))
         guard startOffset + length < stringLength else {
             // We've reached the end of the line.
             return length


### PR DESCRIPTION
I've seen some issues with using CTTypesetterSuggestClusterBreak and these seem to be fixed by using CTTypesetterSuggestLineBreak. Specifically, CTTypesetterSuggestClusterBreak would aggressively introduce line breaks in files that used CRLF line endings.

Now that there's logic for preferring line breaks on whitespace and punctuation characters, it seems fine to use CTTypesetterSuggestLineBreak.

This may come at a performance cost that's important to keep an eye on.