### PR TITLE
Adds Tree-sitter submoduel with HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tree-sitter"]
 	path = tree-sitter
-	url = git@github.com:tree-sitter/tree-sitter.git
+	url = https://github.com/tree-sitter/tree-sitter.git


### PR DESCRIPTION
The Tree-sitter submodule is now added using HTTPS rather than SSH, so people who haven't setup SSH can add Runestone as a dependency using SPM.