### PR TITLE
Removes unsafe build flag from TreeSitter target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,8 +36,7 @@ let package = Package(
                     "src/tree.c",
                     "src/query.c"
                 ],
-                sources: ["src/lib.c"],
-                cSettings: [.unsafeFlags(["-w"])]),
+                sources: ["src/lib.c"]),
         .target(name: "TestTreeSitterLanguages", cSettings: [.unsafeFlags(["-w"])]),
         .testTarget(name: "RunestoneTests", dependencies: ["Runestone", "TestTreeSitterLanguages"])
     ]

--- a/Sources/Runestone/Language/Internal/TreeSitter/TreeSitterTextPredicatesEvaluator.swift
+++ b/Sources/Runestone/Language/Internal/TreeSitter/TreeSitterTextPredicatesEvaluator.swift
@@ -34,7 +34,8 @@ final class TreeSitterTextPredicatesEvaluator {
                 #if DEBUG
                 if !Self.previousUnsupportedPredicateNames.contains(parameters.name) {
                     Self.previousUnsupportedPredicateNames.append(parameters.name)
-                    print("Unsupported predicate '\(parameters.name)'. This message is only printed once and only when running in the debug configuration.")
+                    print("Unsupported predicate '\(parameters.name)'."
+                          + " This message is only printed once and only when running in the debug configuration.")
                 }
                 #endif
                 return false

--- a/Sources/Runestone/Library/TextEditHelper.swift
+++ b/Sources/Runestone/Library/TextEditHelper.swift
@@ -41,6 +41,7 @@ final class TextEditHelper {
 
     func string(byApplying batchReplaceSet: BatchReplaceSet) -> NSString {
         let sortedReplacements = batchReplaceSet.replacements.sorted { $0.range.lowerBound < $1.range.lowerBound }
+        // swiftlint:disable:next force_cast
         let mutableSubstring = stringView.string.mutableCopy() as! NSMutableString
         var totalChangeInLength = 0
         var replacedRanges: [NSRange] = []

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import CoreGraphics
 import CoreText
 import UIKit

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable file_length
-
 import UIKit
 
 protocol TextInputViewDelegate: AnyObject {
@@ -43,15 +42,15 @@ final class TextInputView: UIView, UITextInput {
         }
     }
     private(set) var markedTextRange: UITextRange? {
-        set {
-            markedRange = (newValue as? IndexedRange)?.range
-        }
         get {
             if let markedRange = markedRange {
                 return IndexedRange(markedRange)
             } else {
                 return nil
             }
+        }
+        set {
+            markedRange = (newValue as? IndexedRange)?.range
         }
     }
     var markedTextStyle: [NSAttributedString.Key: Any]?
@@ -485,11 +484,11 @@ final class TextInputView: UIView, UITextInput {
     private let lineMovementController: LineMovementController
     private let pageGuideController = PageGuideController()
     private var markedRange: NSRange? {
-        set {
-            layoutManager.markedRange = newValue
-        }
         get {
             return layoutManager.markedRange
+        }
+        set {
+            layoutManager.markedRange = newValue
         }
     }
     private var floatingCaretView: FloatingCaretView?
@@ -965,9 +964,11 @@ extension TextInputView {
         guard newString != string else {
             return
         }
+        guard let oldString = stringView.string.copy() as? NSString else {
+            return
+        }
         timedUndoManager.endUndoGrouping()
         let oldSelectedRange = selectedRange
-        let oldString = stringView.string.copy() as! NSString
         string = newString
         timedUndoManager.beginUndoGrouping()
         timedUndoManager.setActionName(L10n.Undo.ActionName.replaceAll)

--- a/Sources/Runestone/TreeSitter/TreeSitterPredicateMapper.swift
+++ b/Sources/Runestone/TreeSitter/TreeSitterPredicateMapper.swift
@@ -25,7 +25,6 @@ enum TreeSitterPredicateMapper {
             default:
                 let parameters = TreeSitterTextPredicate.UnsupportedParameters(name: predicate.name)
                 textPredicates.append(.unsupported(parameters))
-                break
             }
         }
         return MapResult(properties: properties, textPredicates: textPredicates)

--- a/Sources/Runestone/TreeSitter/TreeSitterTextInput.swift
+++ b/Sources/Runestone/TreeSitter/TreeSitterTextInput.swift
@@ -32,7 +32,10 @@ final class TreeSitterTextInput {
     }
 }
 
-private func read(payload: UnsafeMutableRawPointer?, byteIndex: UInt32, position: TSPoint, bytesRead: UnsafeMutablePointer<UInt32>?) -> UnsafePointer<Int8>? {
+private func read(payload: UnsafeMutableRawPointer?,
+                  byteIndex: UInt32,
+                  position: TSPoint,
+                  bytesRead: UnsafeMutablePointer<UInt32>?) -> UnsafePointer<Int8>? {
     let input: TreeSitterTextInput = Unmanaged.fromOpaque(payload!).takeUnretainedValue()
     if let result = input.callback(ByteCount(byteIndex), TreeSitterTextPoint(position)) {
         bytesRead?.pointee = result.length

--- a/Tests/RunestoneTests/Mock/MockTreeSitterParserDelegate.swift
+++ b/Tests/RunestoneTests/Mock/MockTreeSitterParserDelegate.swift
@@ -15,7 +15,7 @@ final class MockTreeSitterParserDelegate: TreeSitterParserDelegate {
 
     func parser(_ parser: TreeSitterParser, bytesAt byteIndex: ByteCount) -> TreeSitterTextProviderResult? {
         let maxLength = stringView.string.byteCount - byteIndex
-        let length = min(2048, maxLength)
+        let length = min(2_048, maxLength)
         let byteRange = ByteRange(location: byteIndex, length: length)
         if let result = stringView.bytes(in: byteRange) {
             return TreeSitterTextProviderResult(bytes: result.bytes, length: UInt32(result.length.value))


### PR DESCRIPTION
Xcode does not allow pinning to a version range of a Swift package that includes unsafe build flags. However, it is possible to pin to a specific branch or commit.

This PR removes the unsafe build flag from Runestone that was used to suppress warnings in third-party C code to allow developers to pin to a version range.

![simonbs_2022-May-06](https://user-images.githubusercontent.com/830995/167080254-45b60eb0-2f30-44be-8d34-bb8a062b6172.jpg)