### PR TITLE
Returns no selection rects when range is empty

### DIFF
--- a/Sources/Runestone/TextView/TextInput/LayoutManager.swift
+++ b/Sources/Runestone/TextView/TextInput/LayoutManager.swift
@@ -477,6 +477,9 @@ extension LayoutManager {
     }
 
     func selectionRects(in range: NSRange) -> [TextSelectionRect] {
+        guard range.length > 0 else {
+            return []
+        }
         guard let endLine = lineManager.line(containingCharacterAt: range.upperBound) else {
             return []
         }


### PR DESCRIPTION
This fixes an issue where the selecting an empty line would scroll to the end of the document as well as other strange scrolling behaviours.