### PR TITLE
Ensures caret is visible when moved past trailing edge

### DIFF
--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -927,7 +927,7 @@ private extension TextView {
             newContentOffset.x = caretRect.minX - gutterWidth - automaticScrollInset.left
         }
         if caretRect.maxX > viewport.maxX {
-            newContentOffset.x = caretRect.minX - viewport.width - gutterWidth + automaticScrollInset.right
+            newContentOffset.x = caretRect.maxX - viewport.width - gutterWidth + automaticScrollInset.right
         }
         if caretRect.minY < viewport.minY {
             newContentOffset.y = caretRect.minY - automaticScrollInset.top


### PR DESCRIPTION
Fixes a bug where the caret wasn't visible when moved past the trailing edge.