### PR TITLE
Skip empty captures

### DIFF
--- a/Sources/Runestone/TreeSitter/TreeSitterQueryCursor.swift
+++ b/Sources/Runestone/TreeSitter/TreeSitterQueryCursor.swift
@@ -47,7 +47,7 @@ final class TreeSitterQueryCursor {
             let match = TreeSitterQueryMatch(captures: captures)
             let evaluator = TreeSitterTextPredicatesEvaluator(match: match, stringView: stringView)
             result += captures.filter { capture in
-                return evaluator.evaluatePredicates(in: capture)
+                return capture.byteRange.length > 0 && evaluator.evaluatePredicates(in: capture)
             }
         }
         return result


### PR DESCRIPTION
We might as well filter away captures with an empty text range early since they'll provide no value.