### PR TITLE
Fixes issue where carriage return was not rendered

### DIFF
--- a/Sources/Runestone/TextView/LineController/LineFragmentRenderer.swift
+++ b/Sources/Runestone/TextView/LineController/LineFragmentRenderer.swift
@@ -115,6 +115,6 @@ private extension LineFragmentRenderer {
     }
 
     private func isLineBreak(_ string: String.Element) -> Bool {
-        return string == Symbol.Character.lineFeed || string == Symbol.Character.carriageReturnLineFeed
+        return string == Symbol.Character.lineFeed || string == Symbol.Character.carriageReturn || string == Symbol.Character.carriageReturnLineFeed
     }
 }


### PR DESCRIPTION
This PR fixes an issue where carriage return (\r) was not drawn as an invisible character. The following characters are now considered as line breaks and rendered:

- Line feed (\n)
- Carriage return (\r)
- Carriage return and line feed (\r\n)