### PR TITLE
Adds support for specifying line endings

### DIFF
--- a/Sources/Runestone/Library/LineEndingDetector.swift
+++ b/Sources/Runestone/Library/LineEndingDetector.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+final class LineEndingDetector {
+    private let lineManager: LineManager
+    private let stringView: StringView
+
+    init(lineManager: LineManager, stringView: StringView) {
+        self.lineManager = lineManager
+        self.stringView = stringView
+    }
+
+    func detect() -> LineEnding? {
+        var shouldScan = true
+        let iterator = lineManager.createLineIterator()
+        let lineCount = lineManager.lineCount
+        var scannedLineCount = 0
+        var lineEndingCountMap: [LineEnding: Int] = [:]
+        while let line = iterator.next(), shouldScan {
+            let lineLocation = line.location
+            let lineLength = line.data.totalLength
+            let delimiterLength = line.data.delimiterLength
+            let delimiterRange = NSRange(location: lineLocation + lineLength - delimiterLength, length: delimiterLength)
+            if let character = stringView.substring(in: delimiterRange), let lineEnding = LineEnding(symbol: character) {
+                scannedLineCount += 1
+                let count = lineEndingCountMap[lineEnding] ?? 0
+                lineEndingCountMap[lineEnding] = count + 1
+            }
+            let hasScannedEnoughLines = scannedLineCount >= min(lineCount, 20)
+            if hasScannedEnoughLines {
+                shouldScan = false
+            }
+        }
+        let fallbackOrder = LineEnding.allCases
+        let maxCountLineEnding = lineEndingCountMap.max { lhsPair, rhsPair in
+            if lhsPair.value < rhsPair.value {
+                return true
+            } else if lhsPair.value > rhsPair.value {
+                return false
+            } else {
+                let lhsIndex = fallbackOrder.firstIndex(of: lhsPair.key)!
+                let rhsIndex = fallbackOrder.firstIndex(of: rhsPair.key)!
+                return lhsIndex > rhsIndex
+            }
+        }
+        return maxCountLineEnding?.key
+    }
+}

--- a/Sources/Runestone/TextView/LineEnding.swift
+++ b/Sources/Runestone/TextView/LineEnding.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Line ending character to use when inserting a line break in the text view.
+public enum LineEnding: String, CaseIterable {
+    /// Unix (LF) line endings.
+    ///
+    /// Uses the `\n` character.
+    case lf
+    /// Windows (CRLF) line endings.
+    ///
+    /// Uses the `\c\n` character.
+    case crlf
+    /// Mac (CR) line endings.
+    ///
+    /// Uses the `\r` character.
+    case cr
+
+    var symbol: String {
+        switch self {
+        case .cr:
+            return Symbol.carriageReturn
+        case .lf:
+            return Symbol.lineFeed
+        case .crlf:
+            return Symbol.carriageReturnLineFeed
+        }
+    }
+
+    init?(symbol: String) {
+        if symbol == Self.cr.symbol {
+            self = .cr
+        } else if symbol == Self.lf.symbol {
+            self = .lf
+        } else if symbol == Self.crlf.symbol {
+            self = .crlf
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/Runestone/TextView/TextInput/IndentController.swift
+++ b/Sources/Runestone/TextView/TextInput/IndentController.swift
@@ -7,30 +7,6 @@ protocol IndentControllerDelegate: AnyObject {
 }
 
 final class IndentController {
-    enum LineBreak: String {
-        case lineFeed
-        case carriageReturnLineFeed
-
-        var rawValue: String {
-            switch self {
-            case .lineFeed:
-                return Symbol.lineFeed
-            case .carriageReturnLineFeed:
-                return Symbol.carriageReturnLineFeed
-            }
-        }
-
-        init?(rawValue: String) {
-            if rawValue == Symbol.lineFeed {
-                self = .lineFeed
-            } else if rawValue == Symbol.carriageReturnLineFeed {
-                self = .carriageReturnLineFeed
-            } else {
-                return nil
-            }
-        }
-    }
-
     weak var delegate: IndentControllerDelegate?
     var stringView: StringView
     var lineManager: LineManager
@@ -112,8 +88,8 @@ final class IndentController {
         delegate?.indentController(self, shouldSelect: newSelectedRange)
     }
 
-    func insertLineBreak(in range: NSRange, using lineBreak: LineBreak) {
-        let symbol = lineBreak.rawValue
+    func insertLineBreak(in range: NSRange, using lineEnding: LineEnding) {
+        let symbol = lineEnding.symbol
         if let startLinePosition = lineManager.linePosition(at: range.lowerBound),
             let endLinePosition = lineManager.linePosition(at: range.upperBound) {
             let strategy = languageMode.strategyForInsertingLineBreak(from: startLinePosition, to: endLinePosition, using: indentStrategy)

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -505,6 +505,17 @@ public final class TextView: UIScrollView {
             }
         }
     }
+    /// Line endings to use when inserting a line break.
+    ///
+    /// The value only affects new line breaks inserted in the text view and changing this value does not change the line endings of the text in the text view. Defaults to Unix (LF).
+    public var lineEndings: LineEnding {
+        get {
+            return textInputView.lineEndings
+        }
+        set {
+            textInputView.lineEndings = newValue
+        }
+    }
 
     private let textInputView: TextInputView
     private let editableTextInteraction = UITextInteraction(for: .editable)

--- a/Sources/Runestone/TextView/TextViewState.swift
+++ b/Sources/Runestone/TextView/TextViewState.swift
@@ -14,6 +14,13 @@ public final class TextViewState {
     /// The information provided by the detected strategy can be used to update the ``TextView/indentStrategy`` on the text view to align with the existing strategy in a text.
     public private(set) var detectedIndentStrategy: DetectedIndentStrategy = .unknown
 
+    /// Line endings detected in the dtext.
+    ///
+    /// The information pvoided by the detected line endings can be used to update the ``TextView/lineEndings`` on the text view to align with the existing line endings in a text.
+    ///
+    /// The value is `nil` if the line ending cannot be detected.
+    public private(set) var detectedLineEndings: LineEnding?
+
     /// Creates state that can be passed to an instance of <doc:TextView>.
     /// - Parameters:
     ///   - text: The text to display in the text view.
@@ -54,5 +61,7 @@ private extension TextViewState {
         lineManager.rebuild(from: nsString)
         languageMode.parse(nsString)
         detectedIndentStrategy = languageMode.detectIndentStrategy()
+        let lineEndingDetector = LineEndingDetector(lineManager: lineManager, stringView: stringView)
+        detectedLineEndings = lineEndingDetector.detect()
     }
 }

--- a/Tests/RunestoneTests/LineEndingDetectorTests.swift
+++ b/Tests/RunestoneTests/LineEndingDetectorTests.swift
@@ -1,0 +1,94 @@
+@testable import Runestone
+import XCTest
+
+final class LineEndingDetectorTests: XCTestCase {
+    func testEmptyString() {
+        let string = ""
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertNil(lineEndings)
+    }
+
+    func testNoLineBreakString() {
+        let string = "Hello World!"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, nil)
+    }
+
+    func testLineFeedOnlyString() {
+        let string = "\n"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .lf)
+    }
+
+    func testCarriageReturnOnlyString() {
+        let string = "\r"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .cr)
+    }
+
+    func testCarriageReturnLineFeedOnlyString() {
+        let string = "\r\n"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .crlf)
+    }
+
+    func testStringWithMultipleLineFeed() {
+        let string = "Hello\nworld\nhow\nare\nyou\ndoing"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .lf)
+    }
+
+    func testStringWithMultipleCarriageReturn() {
+        let string = "Hello\rworld\rhow\rare\ryou\rdoing"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .cr)
+    }
+
+    func testStringWithMultipleCarriageLineFeedReturn() {
+        let string = "Hello\r\nworld\r\nhow\r\nare\r\nyou\r\ndoing"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .crlf)
+    }
+
+    func testStringWithEqualNumberOfDifferentLineEndingsStartingWithLineFeed() {
+        // When there's an equal amount of line breaks we fallback to the order of LineEnding.allCases.
+        let string = "Hello\nworld\rhello\nworld\r"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .lf)
+    }
+
+    func testStringWithEqualNumberOfDifferentLineEndingsStartignWithCarriageReturn() {
+        // When there's an equal amount of line breaks we fallback to the order of LineEnding.allCases.
+        let string = "Hello\rworld\nhello\rworld\n"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .lf)
+    }
+
+    func testStringWithDominantLineFeed() {
+        let string = "Hello\nworld\nhello\rworld\n"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .lf)
+    }
+
+    func testStringWithDominantCarriageReturn() {
+        let string = "Hello\rworld\rhello\nworld\r"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .cr)
+    }
+
+    func testStringWithDominantCarriageReturnLineFeed() {
+        let string = "Hello\r\nworld\r\nhello\rworld\r\n"
+        let lineEndings = detectLineEndings(in: string)
+        XCTAssertEqual(lineEndings, .crlf)
+    }
+}
+
+private extension LineEndingDetectorTests {
+    private func detectLineEndings(in string: String) -> LineEnding? {
+        let stringView = StringView(string: string)
+        let lineManager = LineManager(stringView: stringView)
+        lineManager.rebuild(from: string as NSString)
+        let detector = LineEndingDetector(lineManager: lineManager, stringView: stringView)
+        return detector.detect()
+    }
+}


### PR DESCRIPTION
This PR adds the new `lineEndings` property to TextView. This is used to specify the character to use when inserting a line break. It can be either CR (\r), LF (\n) or CRLF (\r\n).

In addition Runestone will now detect the line endings used in a document by examining the first 20 lines when creating an instance of TextViewState. The detected line endings can be used to update the `lineEndings` property with the dominant type of line endings in the file.