### PR TITLE
Considers Windows-style line breaks (\r\n) a composed character sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Runestone uses GitHub's [Tree-sitter](https://tree-sitter.github.io/tree-sitter/
 - Highlight ranges in the text view.
 - Search the text using regular expressions.
 - Automatically detects if a file is using spaces or tabs for indentation.
+- Specify line endings (CR, LF, CRLF) to use when inserting a line break.
+- Automatically detect line endings in a text.
 
 ## 🚀 Getting Started
 

--- a/Sources/Runestone/Library/NSString+Helpers.swift
+++ b/Sources/Runestone/Library/NSString+Helpers.swift
@@ -27,4 +27,38 @@ extension NSString {
             return nil
         }
     }
+
+    /// A wrapper around `rangeOfComposedCharacterSequences(for:)` that considers CRLF line endings as composed character sequences.
+    func customRangeOfComposedCharacterSequence(at location: Int) -> NSRange {
+        let range = NSRange(location: location, length: 0)
+        return customRangeOfComposedCharacterSequences(for: range)
+    }
+
+    /// A wrapper around `rangeOfComposedCharacterSequences(for:)` that considers CRLF line endings as composed character sequences.
+    func customRangeOfComposedCharacterSequences(for range: NSRange) -> NSRange {
+        let defaultRange = rangeOfComposedCharacterSequences(for: range)
+        var location = defaultRange.location
+        var length = defaultRange.length
+        if defaultRange.location > 0 {
+            let candidateCRLFRange = NSRange(location: range.location - 1, length: 2)
+            if isCRLFLineEnding(in: candidateCRLFRange) {
+                location -= 1
+                length += 1
+            }
+        }
+        if defaultRange.upperBound < length - 1 {
+            let candidateCRLFRange = NSRange(location: range.upperBound, length: 2)
+            if isCRLFLineEnding(in: candidateCRLFRange) {
+                location -= 1
+                length += 1
+            }
+        }
+        return NSRange(location: location, length: length)
+    }
+}
+
+private extension NSString {
+    private func isCRLFLineEnding(in range: NSRange) -> Bool {
+        return substring(with: range) == Symbol.carriageReturnLineFeed
+    }
 }

--- a/Sources/Runestone/TextView/TextInput/LineMovementController.swift
+++ b/Sources/Runestone/TextView/TextInput/LineMovementController.swift
@@ -61,7 +61,7 @@ private extension LineMovementController {
         guard naiveNewLocation > 0 && naiveNewLocation < stringView.string.length else {
             return naiveNewLocation
         }
-        let range = stringView.string.rangeOfComposedCharacterSequence(at: naiveNewLocation)
+        let range = stringView.string.customRangeOfComposedCharacterSequence(at: naiveNewLocation)
         guard naiveNewLocation > range.location && naiveNewLocation < range.location + range.length else {
             return naiveNewLocation
         }

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -1028,7 +1028,7 @@ extension TextInputView {
         if range.length == 1, let indentRange = indentController.indentRangeInFrontOfLocation(range.upperBound) {
             resultingRange = indentRange
         } else {
-            resultingRange = string.rangeOfComposedCharacterSequences(for: range)
+            resultingRange = string.customRangeOfComposedCharacterSequences(for: range)
         }
         // If deleting the leading component of a character pair we may also expand the range to delete the trailing component.
         if characterPairTrailingComponentDeletionMode == .immediatelyFollowingLeadingComponent
@@ -1356,8 +1356,8 @@ extension TextInputView: TreeSitterLanguageModeDelegate {
         let targetCharacterCount = 4 * 1_024
         let startLocation = byteIndex.utf16Length
         let endLocation = min(startLocation + targetCharacterCount, stringView.string.length - 1)
-        let startRange = string.rangeOfComposedCharacterSequence(at: startLocation)
-        let endRange = string.rangeOfComposedCharacterSequence(at: endLocation)
+        let startRange = string.customRangeOfComposedCharacterSequence(at: startLocation)
+        let endRange = string.customRangeOfComposedCharacterSequence(at: endLocation)
         let byteLocation = ByteCount(utf16Length: startRange.location)
         let byteLength = ByteCount(utf16Length: endRange.upperBound - startRange.lowerBound)
         let byteRange = ByteRange(location: byteLocation, length: byteLength)

--- a/Tests/RunestoneTests/NSStringHelpersTests.swift
+++ b/Tests/RunestoneTests/NSStringHelpersTests.swift
@@ -26,4 +26,22 @@ final class NSStringHelpersTests: XCTestCase {
         let str = "👨‍👩‍👧‍👦" as NSString
         XCTAssertEqual(str.byteCount, 22)
     }
+
+    func testComposedCharacterSequenceOfFirstLetter() {
+        let str = "Hello\r\nWorld" as NSString
+        let range = str.customRangeOfComposedCharacterSequence(at: 0)
+        XCTAssertEqual(range, NSRange(location: 0, length: 1))
+    }
+
+    func testComposedCharacterSequenceOfSecondLetter() {
+        let str = "Hello\r\nWorld" as NSString
+        let range = str.customRangeOfComposedCharacterSequence(at: 1)
+        XCTAssertEqual(range, NSRange(location: 1, length: 1))
+    }
+
+    func testComposedCharacterSequenceOfCRLF() {
+        let str = "Hello\r\nWorld" as NSString
+        let range = str.customRangeOfComposedCharacterSequence(at: 6)
+        XCTAssertEqual(range, NSRange(location: 5, length: 2))
+    }
 }


### PR DESCRIPTION
This fixes an issue where navigating the text with the arrow keys on a keyboard could cause the caret to be placed in the middle of a line break when using Windows-style line breaks.