### PR TITLE
Add isEditable and isSelectable property to TextView

### DIFF
--- a/Example/Example/Library/TextView+Helpers.swift
+++ b/Example/Example/Library/TextView+Helpers.swift
@@ -44,6 +44,8 @@ extension TextView {
         showSpaces = settings.showInvisibleCharacters
         showLineBreaks = settings.showInvisibleCharacters
         isLineWrappingEnabled = settings.wrapLines
+        isEditable = settings.isEditable
+        isSelectable = settings.isSelectable
         lineSelectionDisplayType = settings.highlightSelectedLine ? .line : .disabled
         showPageGuide = settings.showPageGuide
     }

--- a/Example/Example/Library/UserDefaults+Helpers.swift
+++ b/Example/Example/Library/UserDefaults+Helpers.swift
@@ -73,7 +73,7 @@ extension UserDefaults {
             set(newValue.rawValue, forKey: Key.theme)
         }
     }
-    
+
     var isEditable: Bool {
         get {
             return bool(forKey: Key.isEditable)
@@ -82,7 +82,7 @@ extension UserDefaults {
             set(newValue, forKey: Key.isEditable)
         }
     }
-    
+
     var isSelectable: Bool {
         get {
             return bool(forKey: Key.isSelectable)

--- a/Example/Example/Library/UserDefaults+Helpers.swift
+++ b/Example/Example/Library/UserDefaults+Helpers.swift
@@ -9,6 +9,8 @@ extension UserDefaults {
         static let highlightSelectedLine = "RunestoneExample.highlightSelectedLine"
         static let showPageGuide = "RunestoneExample.showPageGuide"
         static let theme = "RunestoneExample.theme"
+        static let isEditable = "RunestoneExample.isEditable"
+        static let isSelectable = "RunestoneExample.isSelectable"
     }
 
     var text: String? {
@@ -71,13 +73,33 @@ extension UserDefaults {
             set(newValue.rawValue, forKey: Key.theme)
         }
     }
+    
+    var isEditable: Bool {
+        get {
+            return bool(forKey: Key.isEditable)
+        }
+        set {
+            set(newValue, forKey: Key.isEditable)
+        }
+    }
+    
+    var isSelectable: Bool {
+        get {
+            return bool(forKey: Key.isSelectable)
+        }
+        set {
+            set(newValue, forKey: Key.isSelectable)
+        }
+    }
 
     func registerDefaults() {
         register(defaults: [
             Key.text: CodeSample.default,
             Key.showLineNumbers: true,
             Key.wrapLines: false,
-            Key.highlightSelectedLine: true
+            Key.highlightSelectedLine: true,
+            Key.isEditable: true,
+            Key.isSelectable: true
         ])
     }
 }

--- a/Example/Example/Main/MainViewController.swift
+++ b/Example/Example/Main/MainViewController.swift
@@ -78,12 +78,12 @@ private extension MainViewController {
                 self?.updateTextViewSettings()
                 self?.setupMenuButton()
             },
-            UIAction(title: "Editable", state: settings.isEditable ? .on : .off) { [weak self] _ in
+            UIAction(title: "Allow Editing", state: settings.isEditable ? .on : .off) { [weak self] _ in
                 settings.isEditable.toggle()
                 self?.updateTextViewSettings()
                 self?.setupMenuButton()
             },
-            UIAction(title: "Selectable", state: settings.isSelectable ? .on : .off) { [weak self] _ in
+            UIAction(title: "Allow Selection", state: settings.isSelectable ? .on : .off) { [weak self] _ in
                 settings.isSelectable.toggle()
                 self?.updateTextViewSettings()
                 self?.setupMenuButton()

--- a/Example/Example/Main/MainViewController.swift
+++ b/Example/Example/Main/MainViewController.swift
@@ -77,6 +77,16 @@ private extension MainViewController {
                 settings.showPageGuide.toggle()
                 self?.updateTextViewSettings()
                 self?.setupMenuButton()
+            },
+            UIAction(title: "Editable", state: settings.isEditable ? .on : .off) { [weak self] _ in
+                settings.isEditable.toggle()
+                self?.updateTextViewSettings()
+                self?.setupMenuButton()
+            },
+            UIAction(title: "Selectable", state: settings.isSelectable ? .on : .off) { [weak self] _ in
+                settings.isSelectable.toggle()
+                self?.updateTextViewSettings()
+                self?.setupMenuButton()
             }
         ])
         let miscMenu = UIMenu(options: .displayInline, children: [

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -684,6 +684,13 @@ final class TextInputView: UIView, UITextInput {
         }
     }
 
+    func clearSelection() {
+        inputDelegate?.selectionWillChange(self)
+        selectedRange = nil
+        inputDelegate?.selectionDidChange(self)
+        delegate?.textInputViewDidChangeSelection(self)
+    }
+
     func moveCaret(to point: CGPoint) {
         if let index = layoutManager.closestIndex(to: point) {
             let newSelectedRange = NSRange(location: index, length: 0)

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -1224,6 +1224,7 @@ extension TextView: UITextInteractionDelegate {
         if interaction.textInteractionMode == .editable {
             return isEditable
         } else if interaction.textInteractionMode == .nonEditable {
+            // The private UITextLoupeInteraction and UITextNonEditableInteractionclass will end up in this case. The latter is likely created from UITextInteraction(for: .nonEditable) but we want to disable both when selection is disabled.
             return isSelectable
         } else {
             return true

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -46,7 +46,7 @@ public final class TextView: UIScrollView {
     public var isSelectable = true {
         didSet {
             textInputView.isUserInteractionEnabled = isSelectable
-            // xxx: remove current selection
+            textInputView.moveCaret(to: .zero)
         }
     }
 

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -42,6 +42,13 @@ public final class TextView: UIScrollView {
         }
     }
     
+    /// A Boolean value that indicates whether the text view is selectable.
+    public var isSelectable: Bool = true {
+        didSet {
+            textInputView.isUserInteractionEnabled = isSelectable
+        }
+    }
+    
     /// Colors and fonts to be used by the editor.
     public var theme: Theme {
         get {
@@ -874,6 +881,9 @@ public final class TextView: UIScrollView {
 
 private extension TextView {
     @objc private func handleTap(_ gestureRecognizer: UITapGestureRecognizer) {
+        guard isSelectable else {
+            return
+        }
         if gestureRecognizer.state == .ended {
             willBeginEditingFromNonEditableTextInteraction = false
             let point = gestureRecognizer.location(in: textInputView)

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -36,8 +36,9 @@ public final class TextView: UIScrollView {
     /// A Boolean value that indicates whether the text view is editable.
     public var isEditable = true {
         didSet {
-            if !isEditable {
-                self.textInputViewDidEndEditing(textInputView)
+            if isEditable != oldValue && !isEditable {
+                resignFirstResponder()
+                textInputViewDidEndEditing(textInputView)
             }
         }
     }

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -1223,6 +1223,16 @@ extension TextView: KeyboardObserverDelegate {
 }
 
 extension TextView: UITextInteractionDelegate {
+    public func interactionShouldBegin(_ interaction: UITextInteraction, at point: CGPoint) -> Bool {
+        if interaction.textInteractionMode == .editable {
+            return isEditable
+        } else if interaction.textInteractionMode == .nonEditable {
+            return isSelectable
+        } else {
+            return true
+        }
+    }
+
     public func interactionWillBegin(_ interaction: UITextInteraction) {
         if interaction.textInteractionMode == .nonEditable {
             // When long-pressing our instance of UITextInput, the UITextInteraction will make the text input first responder.

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -32,6 +32,16 @@ public final class TextView: UIScrollView {
             contentSize = preferredContentSize
         }
     }
+    
+    /// A Boolean value that indicates whether the text view is editable.
+    public var isEditable: Bool = true {
+        didSet {
+            if !isEditable {
+                self.textInputViewDidEndEditing(textInputView)
+            }
+        }
+    }
+    
     /// Colors and fonts to be used by the editor.
     public var theme: Theme {
         get {
@@ -190,7 +200,7 @@ public final class TextView: UIScrollView {
     }
     /// Returns a Boolean value indicating whether this object can become the first responder.
     override public var canBecomeFirstResponder: Bool {
-        return !textInputView.isFirstResponder
+        return !textInputView.isFirstResponder && isEditable
     }
     /// The text view's background color.
     override public var backgroundColor: UIColor? {
@@ -527,6 +537,9 @@ public final class TextView: UIScrollView {
     private let _inputAssistantItem = UITextInputAssistantItem()
     private var willBeginEditingFromNonEditableTextInteraction = false
     private var delegateAllowsEditingToBegin: Bool {
+        guard isEditable else {
+            return false
+        }
         if let editorDelegate = editorDelegate {
             return editorDelegate.textViewShouldBeginEditing(self)
         } else {
@@ -1033,6 +1046,9 @@ private extension TextView {
 // MARK: - TextInputViewDelegate
 extension TextView: TextInputViewDelegate {
     func textInputViewWillBeginEditing(_ view: TextInputView) {
+        guard isEditable else {
+            return
+        }
         isEditing = !willBeginEditingFromNonEditableTextInteraction
         // If a developer is programmatically calling becomeFirstresponder() then we might not have a selected range.
         // We set the selectedRange instead of the selectedTextRange to avoid invoking any delegates.

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -46,6 +46,7 @@ public final class TextView: UIScrollView {
     public var isSelectable: Bool = true {
         didSet {
             textInputView.isUserInteractionEnabled = isSelectable
+            // xxx: remove current selection
         }
     }
     

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -32,7 +32,6 @@ public final class TextView: UIScrollView {
             contentSize = preferredContentSize
         }
     }
-
     /// A Boolean value that indicates whether the text view is editable.
     public var isEditable = true {
         didSet {
@@ -42,7 +41,6 @@ public final class TextView: UIScrollView {
             }
         }
     }
-
     /// A Boolean value that indicates whether the text view is selectable.
     public var isSelectable = true {
         didSet {
@@ -52,7 +50,6 @@ public final class TextView: UIScrollView {
             }
         }
     }
-
     /// Colors and fonts to be used by the editor.
     public var theme: Theme {
         get {

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -32,24 +32,24 @@ public final class TextView: UIScrollView {
             contentSize = preferredContentSize
         }
     }
-    
+
     /// A Boolean value that indicates whether the text view is editable.
-    public var isEditable: Bool = true {
+    public var isEditable = true {
         didSet {
             if !isEditable {
                 self.textInputViewDidEndEditing(textInputView)
             }
         }
     }
-    
+
     /// A Boolean value that indicates whether the text view is selectable.
-    public var isSelectable: Bool = true {
+    public var isSelectable = true {
         didSet {
             textInputView.isUserInteractionEnabled = isSelectable
             // xxx: remove current selection
         }
     }
-    
+
     /// Colors and fonts to be used by the editor.
     public var theme: Theme {
         get {

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -46,7 +46,11 @@ public final class TextView: UIScrollView {
         didSet {
             if isSelectable != oldValue {
                 textInputView.isUserInteractionEnabled = isSelectable
-                textInputView.clearSelection()
+                if !isSelectable && isEditing {
+                    resignFirstResponder()
+                    textInputView.clearSelection()
+                    textInputViewDidEndEditing(textInputView)
+                }
             }
         }
     }

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -46,8 +46,10 @@ public final class TextView: UIScrollView {
     /// A Boolean value that indicates whether the text view is selectable.
     public var isSelectable = true {
         didSet {
-            textInputView.isUserInteractionEnabled = isSelectable
-            textInputView.moveCaret(to: .zero)
+            if isSelectable != oldValue {
+                textInputView.isUserInteractionEnabled = isSelectable
+                textInputView.clearSelection()
+            }
         }
     }
 

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -35,7 +35,7 @@ public final class TextView: UIScrollView {
     /// A Boolean value that indicates whether the text view is editable.
     public var isEditable = true {
         didSet {
-            if isEditable != oldValue && !isEditable {
+            if isEditable != oldValue && !isEditable && isEditing {
                 resignFirstResponder()
                 textInputViewDidEndEditing(textInputView)
             }


### PR DESCRIPTION
Closes #34

* When `isEditable` is `true`,  text is still selectable and users are able to copy the text.
* When `isSelectable` is `true` then the user will not be able to do anything to the text.