### PR TITLE
Prefer `` when linking to symbols within the package

### DIFF
--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -9,8 +9,8 @@ import UIKit
 ///
 /// The type does not subclass `UITextView` but its interface is kept close to `UITextView`.
 ///
-/// When initially configuring the `TextView` with a theme, a language and the text to be shown, it is recommended the use the <doc:setState(_:addUndoAction:)> function.
-/// The function takes an instance of <doc:TextViewState> as input which can be created on a background queue to avoid blocking the main queue while doing the initial parse of a text.
+/// When initially configuring the `TextView` with a theme, a language and the text to be shown, it is recommended to use the ``setState(_:addUndoAction:)`` function.
+/// The function takes an instance of ``TextViewState`` as input which can be created on a background queue to avoid blocking the main queue while doing the initial parse of a text.
 public final class TextView: UIScrollView {
     /// Delegate to receive callbacks for events triggered by the editor.
     public weak var editorDelegate: TextViewDelegate?
@@ -531,7 +531,7 @@ public final class TextView: UIScrollView {
     ///
     /// The value only affects new line breaks inserted in the text view and changing this value does not change the line endings of the text in the text view. Defaults to Unix (LF).
     ///
-    /// The TextView will only update the line endings when text is modified through an external event, such as when the user typing on the keyboard, when the user is replacing selected text, and when pasting text into the text view. In all other cases, you should make sure that the text provided to the text view uses the desired line endings. This includes when calling <doc:TextView/setState(_:addUndoAction:)> and <doc:TextView/replaceText(in:)>.
+    /// The TextView will only update the line endings when text is modified through an external event, such as when the user typing on the keyboard, when the user is replacing selected text, and when pasting text into the text view. In all other cases, you should make sure that the text provided to the text view uses the desired line endings. This includes when calling ``TextView/setState(_:addUndoAction:)`` and ``TextView/replaceText(in:)``.
     public var lineEndings: LineEnding {
         get {
             return textInputView.lineEndings

--- a/Sources/Runestone/TextView/TextViewDelegate.swift
+++ b/Sources/Runestone/TextView/TextViewDelegate.swift
@@ -30,7 +30,7 @@ public protocol TextViewDelegate: AnyObject {
     /// Tells the delegate when the text selection changes in the text view.
     /// - Parameter textView: The text view whose selection changed.
     ///
-    /// You can use <doc:TextView/selectedRange> of the text view to get the new selection.
+    /// You can use ``TextView/selectedRange`` of the text view to get the new selection.
     func textViewDidChangeSelection(_ textView: TextView)
     /// Asks the delegate whether to replace the specified text in the text view.
     /// - Parameters:
@@ -79,12 +79,12 @@ public protocol TextViewDelegate: AnyObject {
     /// Tells the delegate that the text view looped to the last highlighted range.
     /// - Parameter textView: The text view that looped to the last highlighted range.
     ///
-    /// The text view will loop to the last highlighted range in response to calling <doc:TextView/selectPreviousHighlightedRange()> while the first highlighted range is selected.
+    /// The text view will loop to the last highlighted range in response to calling ``TextView/selectPreviousHighlightedRange()`` while the first highlighted range is selected.
     func textViewDidLoopToLastHighlightedRange(_ textView: TextView)
     /// Tells the delegate that the text view looped to the first highlighted range.
     /// - Parameter textView: The text view that looped to the first highlighted range.
     ///
-    /// The text view will loop to the first highlighted range in response to calling <doc:TextView/selectNextHighlightedRange()> while the last highlighted range is selected.
+    /// The text view will loop to the first highlighted range in response to calling ``TextView/selectNextHighlightedRange()`` while the last highlighted range is selected.
     func textViewDidLoopToFirstHighlightedRange(_ textView: TextView)
     /// Asks the delegate if the text in the highlighted range can be replaced.
     /// - Parameters:

--- a/Sources/Runestone/TextView/TextViewState.swift
+++ b/Sources/Runestone/TextView/TextViewState.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Encapsulates the bare informations needed to do syntax highlighting in a text view.
 ///
-/// It is recommended to create an instance of `TextViewState` on a background queue and pass it to a <doc:TextView> instead of setting the text, theme and language on the text view separately.
+/// It is recommended to create an instance of `TextViewState` on a background queue and pass it to a ``TextView`` instead of setting the text, theme and language on the text view separately.
 public final class TextViewState {
     let stringView: StringView
     let theme: Theme
@@ -21,7 +21,7 @@ public final class TextViewState {
     /// The value is `nil` if the line ending cannot be detected.
     public private(set) var detectedLineEndings: LineEnding?
 
-    /// Creates state that can be passed to an instance of <doc:TextView>.
+    /// Creates state that can be passed to an instance of ``TextView``.
     /// - Parameters:
     ///   - text: The text to display in the text view.
     ///   - theme: The theme to use when syntax highlighting the text.
@@ -39,9 +39,9 @@ public final class TextViewState {
         prepare(with: text)
     }
 
-    /// Creates state that can be passed to an instance of <doc:TextView>.
+    /// Creates state that can be passed to an instance of ``TextView``.
     ///
-    /// The created theme will use an instance of <doc:PlainTextLanguageMode>.
+    /// The created theme will use an instance of ``PlainTextLanguageMode``.
     /// - Parameters:
     ///   - text: The text to display in the text view.
     ///   - theme: The theme to use when syntax highlighting the text.


### PR DESCRIPTION
Closes #82

This should allow for better copy within Xcode's autocomplete UI to appear in docblocks that previously preferred the `<doc:Link>` style for symbol links.

From Apple's docs:

> When referencing symbols that appear within your Swift framework or package, use symbol links instead. To create a symbol link, wrap the symbol name in a set of double backticks (\`\`).
> In the following example, DocC renders the referenced methods in a monospace font and wraps them in links to the corresponding documentation pages:
>     <pre>You can increase the sloth's energy level by asking them to 
>     \`\`eat(_:quantity:)\`\` or \`\`sleep(in:for:)\`\`.</pre>


See also: https://developer.apple.com/documentation/xcode/formatting-your-documentation-content