### PR TITLE
Don't silently absorb error, at least log it in DEBUG mode

### DIFF
--- a/Sources/Runestone/Language/TreeSitter/TreeSitterLanguage.swift
+++ b/Sources/Runestone/Language/TreeSitter/TreeSitterLanguage.swift
@@ -95,7 +95,14 @@ private extension TreeSitterInternalLanguage {
 
     private static func makeInternalQuery(from query: TreeSitterLanguage.Query?, with language: UnsafePointer<TSLanguage>) -> TreeSitterQuery? {
         if let string = query?.string {
-            return try? TreeSitterQuery(source: string, language: language)
+            do {
+                return try TreeSitterQuery(source: string, language: language)
+            } catch {
+                #if DEBUG
+                print("Invalid TreeSitterLanguage.Query. Error: \(error).")
+                #endif
+                return nil
+            }
         } else {
             return nil
         }


### PR DESCRIPTION
I'm writing my one tree-sitter grammar and Runestone stopped highlighting it, when I updated the grammar. Took me a while to figure out that I had forgotten to also update the highlights.scm file and that the outdated file caused an error that was silently ignored.

Would be nice to at least log those errors while debugging, hence the suggested change.