### PR TITLE
Only set `isPrepared` to true after it really is prepared

### DIFF
--- a/Sources/Runestone/Language/TreeSitter/TreeSitterLanguage.swift
+++ b/Sources/Runestone/Language/TreeSitter/TreeSitterLanguage.swift
@@ -49,8 +49,8 @@ public final class TreeSitterLanguage {
     /// If the language haven't been explicitly prepared, Runestone will automatically do it before it's used.
     public func prepare() {
         if !isPrepared {
-            isPrepared = true
             _internalLanguage = TreeSitterInternalLanguage(self)
+            isPrepared = true
         }
     }
 }


### PR DESCRIPTION
This addresses a race condition when calling something that calls `internalLanguage` in parallel from separate threads. `isPrepared` is then set to true before `_internalLanguage` is assigned, which then triggers the `fatalError` call in line 24.

I encountered this while working on SwiftUI support for Runestone, which then caused a crashed. I'm looking into what exactly caused those multiple calls to that property in the first place (Update: it's SwiftUI calling `makeUIView` twice in quick succession for who-knows-what reason), but it'd be better if it just did the work twice rather than leading to a crash. 

Alternatively, the `prepare()` function could get a lock.