### PR TITLE
Always insert text when calling `insertText(_:)` programmatically

### DIFF
--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -937,18 +937,30 @@ extension TextInputView {
 // MARK: - Editing
 extension TextInputView {
     func insertText(_ text: String) {
+        insertText(text, alwaysInsert: false)
+    }
+    
+    /// - Parameters:
+    ///   - text: Text to insert
+    ///   - alwaysInsert: Set to `true` to ensure that the text is always inserted, even if no
+    ///       caret is present, i.e., even if TextInputView is not the first responder.
+    func insertText(_ text: String, alwaysInsert: Bool) {
         let preparedText = prepareTextForInsertion(text)
-        if let selectedRange = markedRange ?? selectedRange, shouldChangeText(in: selectedRange, replacementText: preparedText) {
+        var selectedRange = markedRange ?? selectedRange
+        if selectedRange == nil, alwaysInsert {
+            selectedRange = NSRange(location: stringView.string.length, length: 0)
+        }
+        if let insertionRange = selectedRange, shouldChangeText(in: insertionRange, replacementText: preparedText) {
             // If we're inserting text then we can't have a marked range. However, UITextInput doesn't always clear the marked range
             // before calling -insertText(_:), so we do it manually. This issue can be tested by entering a backtick (`) in an empty
             // document, then pressing any arrow key (up, right, down or left) followed by the return key.
             // The backtick will remain marked unless we manually clear the marked range.
             markedRange = nil
             if LineEnding(symbol: text) != nil {
-                indentController.insertLineBreak(in: selectedRange, using: lineEndings)
+                indentController.insertLineBreak(in: insertionRange, using: lineEndings)
                 layoutIfNeeded()
             } else {
-                replaceText(in: selectedRange, with: preparedText)
+                replaceText(in: insertionRange, with: preparedText)
             }
         }
     }

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -715,10 +715,10 @@ public final class TextView: UIScrollView {
         textInputView.setLanguageMode(languageMode, completion: completion)
     }
 
-    /// Inserts text at the location of the caret.
-    /// - Parameter text: A text to insert.
+    /// Inserts text at the location of the caret or, if no selection or caret is present, at the end of the text.
+    /// - Parameter text: A string to insert.
     public func insertText(_ text: String) {
-        textInputView.insertText(text)
+        textInputView.insertText(text, alwaysInsert: true)
     }
 
     /// Replaces the text that is in the specified range.


### PR DESCRIPTION
I came across another subtle difference in behaviour when switching to Runestone: When the TextView is not the first responder, programatically calling `insertText` with some text didn't do anything, while my previous implementation that used UITextView did append the text.

This PR changes the behaviour of `TextView.insertText(_:)` to also append the text at the end. I kept the behaviour of `TextInputView.insertText(_:)` the same (i.e., it will not insert the text if there's no marked or selected range) in case that this was on purpose.