### PR TITLE
Improves handling of text selection

### DIFF
--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -186,7 +186,7 @@ public final class TextView: UIScrollView {
             }
         }
         set {
-            textInputView.selectedTextRange = IndexedRange(newValue)
+            textInputView.selectedRange = newValue
         }
     }
     /// The current selection range of the text view as a UITextRange.
@@ -829,11 +829,11 @@ public final class TextView: UIScrollView {
         layoutIfNeeded()
         switch selection {
         case .beginning:
-            textInputView.selectedTextRange = IndexedRange(location: line.location, length: 0)
+            textInputView.selectedRange = NSRange(location: line.location, length: 0)
         case .end:
-            textInputView.selectedTextRange = IndexedRange(location: line.data.length, length: 0)
+            textInputView.selectedRange = NSRange(location: line.data.length, length: line.data.length)
         case .line:
-            textInputView.selectedTextRange = IndexedRange(location: line.location, length: line.data.length)
+            textInputView.selectedRange = NSRange(location: line.location, length: line.data.length)
         }
         return true
     }
@@ -898,9 +898,9 @@ private extension TextView {
         if gestureRecognizer.state == .ended {
             willBeginEditingFromNonEditableTextInteraction = false
             let point = gestureRecognizer.location(in: textInputView)
-            let oldSelectedTextRange = textInputView.selectedTextRange
+            let oldSelectedRange = textInputView.selectedRange
             textInputView.moveCaret(to: point)
-            if textInputView.selectedTextRange != oldSelectedTextRange {
+            if textInputView.selectedRange != oldSelectedRange {
                 layoutIfNeeded()
                 editorDelegate?.textViewDidChangeSelection(self)
             }
@@ -935,15 +935,13 @@ private extension TextView {
         }
         if selectedRange.length == 0 {
             textInputView.insertText(characterPair.leading + characterPair.trailing)
-            let newSelectedRange = NSRange(location: range.location + characterPair.leading.count, length: 0)
-            textInputView.selectedTextRange = IndexedRange(newSelectedRange)
+            textInputView.selectedRange = NSRange(location: range.location + characterPair.leading.count, length: 0)
             return true
         } else if let text = textInputView.text(in: selectedRange) {
             let modifiedText = characterPair.leading + text + characterPair.trailing
             let indexedRange = IndexedRange(selectedRange)
             textInputView.replace(indexedRange, withText: modifiedText)
-            let newSelectedRange = NSRange(location: range.location + characterPair.leading.count, length: range.length)
-            textInputView.selectedTextRange = IndexedRange(newSelectedRange)
+            textInputView.selectedRange = NSRange(location: range.location + characterPair.leading.count, length: range.length)
             return true
         } else {
             return false
@@ -970,8 +968,7 @@ private extension TextView {
 
     private func moveCaret(byOffset offset: Int) {
         if let selectedRange = textInputView.selectedRange {
-            let newSelectedRange = NSRange(location: selectedRange.location + offset, length: 0)
-            textInputView.selectedTextRange = IndexedRange(newSelectedRange)
+            textInputView.selectedRange = NSRange(location: selectedRange.location + offset, length: 0)
         }
     }
 
@@ -1176,7 +1173,7 @@ extension TextView: HighlightNavigationControllerDelegate {
         // Layout lines up until the location of the range so we can scroll to it immediately after.
         textInputView.layoutLines(toLocation: range.upperBound)
         scroll(to: range.location)
-        textInputView.selectedTextRange = IndexedRange(range)
+        textInputView.selectedRange = range
         showMenuForText(in: range)
         switch highlightNavigationRange.loopMode {
         case .previousGoesToLast:


### PR DESCRIPTION
This PR reworks the handling of the text selection, and ultimately, of the text handling. This to ensure proper handling of all cases where the selected text range is changed. Specifically, there are some strict expectations as to when `selectionWillChange` and `selectionDidChange` should be called on the input delegate. I've detected the following two challenging cases.

1. When we’re moving the caret using the arrow keys on the keyboard and UIKit calls the `selectedTextRange` setter, we should call the `selectionWillChange`/`selectionDidChange` delegate functions. Otherwise the caret will not be positioned correctly and navigation will not work properly after tapping to move the caret.
2. When entering Korean input, the `selectedTextRange` may be modified and `deleteBackward()` called to delete previous characters and replace multiple characters with a single character. If `selectionWillChange` is called, the characters will not be inserted correctly into the text view. 

Calling only `selectionDidChange` when setting `selectedTextRange` seems to work for both cases. It feels odd not to call the `selectionWillChange` function though.

With this change there is three ways of updating the text selection.

1. Setting the `selectedTextRange` property. We should never need to call this setter. It will only call the `selectionDidChange` function on the `inputDelegate`. Only UIKit will need to use this.
2. Setting the `selectedRange` property. We should use this by default. It'll call both `selectionWillChange` and `selectionDidChange ` on the `inputDelegate`.
3. Setting the `_selectedRange` property. Setting this only performs the needed layout operations. This is used by the `selectedTextRange` setter and when otherwise needing more fine grained control of which delegate functions are called.