### PR TITLE
Adds UITextInteractions to TextInputView

### DIFF
--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -1080,16 +1080,16 @@ private extension TextView {
     private func installEditableInteraction() {
         if editableTextInteraction.view == nil {
             isInputAccessoryViewEnabled = true
-            removeInteraction(nonEditableTextInteraction)
-            addInteraction(editableTextInteraction)
+            textInputView.removeInteraction(nonEditableTextInteraction)
+            textInputView.addInteraction(editableTextInteraction)
         }
     }
 
     private func installNonEditableInteraction() {
         if nonEditableTextInteraction.view == nil {
             isInputAccessoryViewEnabled = false
-            removeInteraction(editableTextInteraction)
-            addInteraction(nonEditableTextInteraction)
+            textInputView.removeInteraction(editableTextInteraction)
+            textInputView.addInteraction(nonEditableTextInteraction)
             for gestureRecognizer in nonEditableTextInteraction.gesturesForFailureRequirements {
                 gestureRecognizer.require(toFail: tapGestureRecognizer)
             }
@@ -1213,8 +1213,8 @@ extension TextView: TextInputViewDelegate {
         // will cause the caret to disappear. Removing the editable text interaction and adding it back will work around this issue.
         DispatchQueue.main.async {
             if !view.viewHierarchyContainsCaret && self.editableTextInteraction.view != nil {
-                self.removeInteraction(self.editableTextInteraction)
-                self.addInteraction(self.editableTextInteraction)
+                view.removeInteraction(self.editableTextInteraction)
+                view.addInteraction(self.editableTextInteraction)
             }
         }
     }


### PR DESCRIPTION
Starting from iOS 16 instances of UITextInteraction must be added to an instance of UITextInput, otherwise Xcode will show the following warning in the console and the Copy, Paste, and Select All actions in the edit menu will not be shown.

> [Assert] View <Runestone.TextView:0x134074800> does not conform to UITextInput protocol

This PR adds the UITextInteraction to our TextInputView.

|Before|After|
|-|-|
|<img width="375" src="https://user-images.githubusercontent.com/830995/173904544-ce606e02-0091-43af-8883-587bd62b0120.PNG"/>|<img width="375" src="https://user-images.githubusercontent.com/830995/173904540-0da6c470-a789-4df2-ac12-d79a64385c9f.PNG"/>|