### PR TITLE
Long pressing to select text would scroll the text view

### DIFF
--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -1126,7 +1126,7 @@ extension TextView: TextInputViewDelegate {
         isEditing = !willBeginEditingFromNonEditableTextInteraction
         // If a developer is programmatically calling becomeFirstresponder() then we might not have a selected range.
         // We set the selectedRange instead of the selectedTextRange to avoid invoking any delegates.
-        if textInputView.selectedRange == nil {
+        if textInputView.selectedRange == nil && !willBeginEditingFromNonEditableTextInteraction {
             textInputView.selectedRange = NSRange(location: 0, length: 0)
         }
         // Ensure selection is laid out without animation.


### PR DESCRIPTION
This PR fixes an issue where long pressing the text view to select text using the non-editable text interaction would scroll the text view to the top.