### PR TITLE
Exposes more UITextInput functions in TextView

### DIFF
--- a/Sources/Runestone/Documentation.docc/Extensions/TextView.md
+++ b/Sources/Runestone/Documentation.docc/Extensions/TextView.md
@@ -5,6 +5,7 @@
 ### Initialing the Text View
 
 - ``init(frame:)``
+- ``init(coder:)``
 
 ### Responding to Text View Changes
 
@@ -68,6 +69,10 @@
 - ``characterPairs``
 - ``characterPairTrailingComponentDeletionMode``
 
+### Line Endings
+
+- ``lineEndings``
+
 ### Overscroll
 
 - ``verticalOverscrollFactor``
@@ -112,6 +117,8 @@
 
 ### Editing
 
+- ``isEditable``
+- ``isSelectable``
 - ``isEditing``
 - ``text``
 - ``autocapitalizationType``
@@ -120,11 +127,13 @@
 - ``smartDashesType``
 - ``smartInsertDeleteType``
 - ``smartQuotesType``
-- ``text(in:)``
+- ``text(in:)-3lp4v``
+- ``text(in:)-3wzco``
 - ``insertText(_:)``
 - ``replaceText(in:)``
 - ``replace(_:withText:)-7gret``
 - ``replace(_:withText:)-7ugo8``
+- ``deleteBackward()``
 - ``undoManager``
 
 ### Managing the Keyboard
@@ -160,3 +169,24 @@
 - ``becomeFirstResponder()``
 - ``resignFirstResponder()``
 - ``canPerformAction(_:withSender:)``
+
+### UITextInput Conformace
+
+- ``hasText``
+- ``beginningOfDocument``
+- ``endOfDocument``
+- ``markedTextRange``
+- ``tokenizer``
+- ``textRange(from:to:)``
+- ``position(from:offset:)``
+- ``position(from:in:offset:)``
+- ``position(within:farthestIn:)``
+- ``closestPosition(to:)``
+- ``closestPosition(to:within:)``
+- ``compare(_:to:)``
+- ``offset(from:to:)``
+- ``characterRange(at:)``
+- ``characterRange(byExtending:in:)``
+- ``caretRect(for:)``
+- ``firstRect(for:)``
+- ``selectionRects(for:)``

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -1343,7 +1343,16 @@ extension TextInputView {
     }
 
     func closestPosition(to point: CGPoint, within range: UITextRange) -> UITextPosition? {
-        return nil
+        guard let indexedRange = range as? IndexedRange else {
+            return nil
+        }
+        guard let index = layoutManager.closestIndex(to: point) else {
+            return nil
+        }
+        let minimumIndex = indexedRange.range.lowerBound
+        let maximumIndex = indexedRange.range.upperBound
+        let cappedIndex = min(max(index, minimumIndex), maximumIndex)
+        return IndexedPosition(index: cappedIndex)
     }
 
     func textRange(from fromPosition: UITextPosition, to toPosition: UITextPosition) -> UITextRange? {

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -1326,7 +1326,12 @@ extension TextInputView {
     }
 
     func characterRange(at point: CGPoint) -> UITextRange? {
-        return nil
+        guard let index = layoutManager.closestIndex(to: point) else {
+            return nil
+        }
+        let cappedIndex = max(index - 1, 0)
+        let range = stringView.string.customRangeOfComposedCharacterSequence(at: cappedIndex)
+        return IndexedRange(range)
     }
 
     func closestPosition(to point: CGPoint) -> UITextPosition? {

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -1309,7 +1309,20 @@ extension TextInputView {
     }
 
     func characterRange(byExtending position: UITextPosition, in direction: UITextLayoutDirection) -> UITextRange? {
-        return nil
+        // This implementation seems to match the behavior of UITextView.
+        guard let indexedPosition = position as? IndexedPosition else {
+            return nil
+        }
+        switch direction {
+        case .left, .up:
+            let leftIndex = max(indexedPosition.index - 1, 0)
+            return IndexedRange(location: leftIndex, length: indexedPosition.index - leftIndex)
+        case .right, .down:
+            let rightIndex = min(indexedPosition.index + 1, stringView.string.length)
+            return IndexedRange(location: indexedPosition.index, length: rightIndex - indexedPosition.index)
+        @unknown default:
+            return nil
+        }
     }
 
     func characterRange(at point: CGPoint) -> UITextRange? {

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -1284,7 +1284,18 @@ extension TextInputView {
 // MARK: - Ranges and Positions
 extension TextInputView {
     func position(within range: UITextRange, farthestIn direction: UITextLayoutDirection) -> UITextPosition? {
-        return nil
+        // This implementation seems to match the behavior of UITextView.
+        guard let indexedRange = range as? IndexedRange else {
+            return nil
+        }
+        switch direction {
+        case .left, .up:
+            return IndexedPosition(index: indexedRange.range.lowerBound)
+        case .right, .down:
+            return IndexedPosition(index: indexedRange.range.upperBound)
+        @unknown default:
+            return nil
+        }
     }
 
     func position(from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int) -> UITextPosition? {

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -1408,4 +1408,3 @@ extension TextView: UITextInteractionDelegate {
         }
     }
 }
-

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -191,7 +191,12 @@ open class TextView: UIScrollView {
     }
     /// The current selection range of the text view as a UITextRange.
     public var selectedTextRange: UITextRange? {
-        return IndexedRange(selectedRange)
+        get {
+            return textInputView.selectedTextRange
+        }
+        set {
+            textInputView.selectedTextRange = newValue
+        }
     }
     /// The custom input accessory view to display when the receiver becomes the first responder.
     override public var inputAccessoryView: UIView? {
@@ -612,6 +617,8 @@ open class TextView: UIScrollView {
         setupMenuItems()
     }
 
+    /// The initializer has not been implemented.
+    /// - Parameter coder: Not used.
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -751,7 +758,7 @@ open class TextView: UIScrollView {
         textInputView.replaceText(in: batchReplaceSet)
     }
 
-    /// Deletes the character just before the cursor
+    /// Deletes a character from the displayed text.
     public func deleteBackward() {
         textInputView.deleteBackward()
     }
@@ -893,50 +900,148 @@ open class TextView: UIScrollView {
     public func redisplayVisibleLines() {
         textInputView.redisplayVisibleLines()
     }
+}
 
-    /// Text position marking the beginning of the text
+// MARK: - UITextInput
+extension TextView {
+    /// The range of currently marked text in a document.
+    public var markedTextRange: UITextRange? {
+        return textInputView.markedTextRange
+    }
+
+    /// The text position for the beginning of a document.
     public var beginningOfDocument: UITextPosition {
-        textInputView.beginningOfDocument
+        return textInputView.beginningOfDocument
     }
 
-    /// Text position marking the end of the text
+    /// The text position for the end of a document.
     public var endOfDocument: UITextPosition {
-        textInputView.endOfDocument
+        return textInputView.endOfDocument
     }
 
-    /// Text position relative from another text position
-    public func position(from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int) -> UITextPosition? {
-        textInputView.position(from: position, in: direction, offset: offset)
-    }
-
-    /// Text position from another text position by incrementing the index
-    public func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
-        textInputView.position(from: position, offset: offset)
-    }
-
-    /// Closest text position to the provided point
-    public func closestPosition(to point: CGPoint) -> UITextPosition? {
-        textInputView.closestPosition(to: point)
-    }
-
-    /// Translates positions into a text range
+    /// Returns the range between two text positions.
+    /// - Parameters:
+    ///   - fromPosition: An object that represents a location in a document.
+    ///   - toPosition: An object that represents another location in a document.
+    /// - Returns: An object that represents the range between fromPosition and toPosition.
     public func textRange(from fromPosition: UITextPosition, to toPosition: UITextPosition) -> UITextRange? {
-        textInputView.textRange(from: fromPosition, to: toPosition)
+        return textInputView.textRange(from: fromPosition, to: toPosition)
     }
 
-    /// Compare text positions
+    /// Returns the text position at a specified offset from another text position.
+    /// - Parameters:
+    ///   - position: A custom UITextPosition object that represents a location in a document.
+    ///   - offset: A character offset from position. It can be a positive or negative value.
+    /// - Returns: A custom UITextPosition object that represents the location in a document that is at the specified offset from position. Returns nil if the computed text position is less than 0 or greater than the length of the backing string.
+    public func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
+        return textInputView.position(from: position, offset: offset)
+    }
+
+    /// Returns the text position at a specified offset in a specified direction from another text position.
+    /// - Parameters:
+    ///   - position: A custom UITextPosition object that represents a location in a document.
+    ///   - direction: A UITextLayoutDirection constant that represents the direction of the offset from position.
+    ///   - offset: A character offset from position.
+    /// - Returns: Returns the text position at a specified offset in a specified direction from another text position. Returns nil if the computed text position is less than 0 or greater than the length of the backing string.
+    public func position(from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int) -> UITextPosition? {
+        return textInputView.position(from: position, in: direction, offset: offset)
+    }
+
+    /// Returns how one text position compares to another text position.
+    /// - Parameters:
+    ///   - position: A custom object that represents a location within a document.
+    ///   - other: A custom object that represents another location within a document.
+    /// - Returns: A value that indicates whether the two text positions are identical or whether one is before the other.
     public func compare(_ position: UITextPosition, to other: UITextPosition) -> ComparisonResult {
-        textInputView.compare(position, to: other)
+        return textInputView.compare(position, to: other)
     }
 
-    /// Offset between two text positions
+    /// Returns the number of UTF-16 characters between one text position and another text position.
+    /// - Parameters:
+    ///   - from: A custom object that represents a location within a document.
+    ///   - toPosition: A custom object that represents another location within document.
+    /// - Returns: The number of UTF-16 characters between fromPosition and toPosition.
     public func offset(from: UITextPosition, to toPosition: UITextPosition) -> Int {
-        textInputView.offset(from: from, to: toPosition)
+        return textInputView.offset(from: from, to: toPosition)
     }
 
-    /// Translates text ranges into selection rects
+    /// An input tokenizer that provides information about the granularity of text units.
+    public var tokenizer: UITextInputTokenizer {
+        return textInputView.tokenizer
+    }
+
+    /// Returns the text position that is at the farthest extent in a specified layout direction within a range of text.
+    /// - Parameters:
+    ///   - range: A text-range object that demarcates a range of text in a document.
+    ///   - direction: A constant that indicates a direction of layout (right, left, up, down).
+    /// - Returns: A text-position object that identifies a location in the visible text.
+    public func position(within range: UITextRange, farthestIn direction: UITextLayoutDirection) -> UITextPosition? {
+        return textInputView.position(within: range, farthestIn: direction)
+    }
+
+    /// Returns a text range from a specified text position to its farthest extent in a certain direction of layout.
+    /// - Parameters:
+    ///   - position: A text-position object that identifies a location in a document.
+    ///   - direction: A constant that indicates a direction of layout (right, left, up, down).
+    /// - Returns: A text-range object that represents the distance from position to the farthest extent in direction.
+    public func characterRange(byExtending position: UITextPosition, in direction: UITextLayoutDirection) -> UITextRange? {
+        return textInputView.characterRange(byExtending: position, in: direction)
+    }
+
+    /// Returns the first rectangle that encloses a range of text in a document.
+    /// - Parameter range: An object that represents a range of text in a document.
+    /// - Returns: The first rectangle in a range of text. You might use this rectangle to draw a correction rectangle. The “first” in the name refers the rectangle enclosing the first line when the range encompasses multiple lines of text.
+    public func firstRect(for range: UITextRange) -> CGRect {
+        return textInputView.firstRect(for: range)
+    }
+
+    /// Returns a rectangle to draw the caret at a specified insertion point.
+    /// - Parameter position: An object that identifies a location in a text input area.
+    /// - Returns: A rectangle that defines the area for drawing the caret.
+    public func caretRect(for position: UITextPosition) -> CGRect {
+        return textInputView.caretRect(for: position)
+    }
+
+    /// Returns an array of selection rects corresponding to the range of text.
+    /// - Parameter range: An object representing a range in a document’s text.
+    /// - Returns: An array of UITextSelectionRect objects that encompass the selection.
     public func selectionRects(for range: UITextRange) -> [UITextSelectionRect] {
-        textInputView.selectionRects(for: range)
+        return textInputView.selectionRects(for: range)
+    }
+
+    /// Returns the position in a document that is closest to a specified point.
+    /// - Parameter point: A point in the view that is drawing a document’s text.
+    /// - Returns: An object locating a position in a document that is closest to point.
+    public func closestPosition(to point: CGPoint) -> UITextPosition? {
+        return textInputView.closestPosition(to: point)
+    }
+
+    /// Returns the position in a document that is closest to a specified point in a specified range.
+    /// - Parameters:
+    ///   - point: A point in the view that is drawing a document’s text.
+    ///   - range: An object representing a range in a document’s text.
+    /// - Returns: An object representing the character position in range that is closest to point.
+    public func closestPosition(to point: CGPoint, within range: UITextRange) -> UITextPosition? {
+        return textInputView.closestPosition(to: point, within: range)
+    }
+
+    /// Returns the character or range of characters that is at a specified point in a document.
+    /// - Parameter point: A point in the view that is drawing a document’s text.
+    /// - Returns: An object representing a range that encloses a character (or characters) at point.
+    public func characterRange(at point: CGPoint) -> UITextRange? {
+        return textInputView.characterRange(at: point)
+    }
+
+    /// Returns the text in the specified range.
+    /// - Parameter range: A range of text in a document.
+    /// - Returns: A substring of a document that falls within the specified range.
+    public func text(in range: UITextRange) -> String? {
+        return textInputView.text(in: range)
+    }
+
+    /// A Boolean value that indicates whether the text-entry object has any text.
+    public var hasText: Bool {
+        return textInputView.hasText
     }
 }
 
@@ -1303,3 +1408,4 @@ extension TextView: UITextInteractionDelegate {
         }
     }
 }
+


### PR DESCRIPTION
This PR makes it easier to swap a UITextView for Runestone's TextView. UITextView conforms to UITextInput which TextView doesn't. However, TextView exposes properties and methods that match those declared by UITextInput.

In the future it might make sense to have TextView instead of TextInputView conform to UITextInput.