### PR TITLE
💥 Adds matchMethod to SearchQuery

### DIFF
--- a/Sources/Runestone/TextView/SearchReplace/SearchQuery.swift
+++ b/Sources/Runestone/TextView/SearchReplace/SearchQuery.swift
@@ -20,7 +20,7 @@ public struct SearchQuery: Hashable, Equatable {
         case regularExpression
     }
 
-    /// The text to search for. May be a regular expression if ``SearchQuery/matchMethod-swift.property`` is ``SearchQuery/MatchMethod/regularExpression``.
+    /// The text to search for.
     public let text: String
     /// Whether the text is a regular exprssion.
     public let matchMethod: MatchMethod
@@ -55,7 +55,7 @@ public struct SearchQuery: Hashable, Equatable {
     /// Creates a query to search for in the text view.
     /// - Parameters:
     ///   - text: The text to search for. May be a regular expression if `isRegularExpression` is `true`.
-    ///   - matchMethod: Strategy to use when matching the search text against the text in the text view. Defaults to ``SearchQuery/MatchMethod/regularExpression``
+    ///   - matchMethod: Strategy to use when matching the search text against the text in the text view. Defaults to `contains`.
     ///   - isCaseSensitive: Whether to perform a case-sensitive search.
     public init(text: String, matchMethod: MatchMethod = .contains, isCaseSensitive: Bool = false) {
         self.text = text

--- a/Sources/Runestone/TextView/SearchReplace/SearchQuery.swift
+++ b/Sources/Runestone/TextView/SearchReplace/SearchQuery.swift
@@ -6,20 +6,46 @@ import Foundation
 ///
 /// When the query contains a regular expression the capture groups can be referred in a replacement text using $0, $1, $2 etc.
 public struct SearchQuery: Hashable, Equatable {
-    /// The text to search for. May be a regular expression if ``SearchQuery/isRegularExpression`` is `true`.
+    /// Strategy to use when matching the search text against the text in the text view.
+    public enum MatchMethod {
+        /// Word contains the search text.
+        case contains
+        /// Word matches the search text.
+        case fullWord
+        /// Word starts with the search text.
+        case startsWith
+        /// Word ends with the search text.
+        case endsWith
+        /// Treat the search text as a regular expression.
+        case regularExpression
+    }
+
+    /// The text to search for. May be a regular expression if ``SearchQuery/matchMethod-swift.property`` is ``SearchQuery/MatchMethod/regularExpression``.
     public let text: String
     /// Whether the text is a regular exprssion.
-    public let isRegularExpression: Bool
+    public let matchMethod: MatchMethod
     /// Whether to perform a case-sensitive search.
     public let isCaseSensitive: Bool
 
-    private var regularExpressionOptions: NSRegularExpression.Options {
-        var options: NSRegularExpression.Options = []
-        if isRegularExpression {
-            options.insert(.anchorsMatchLines)
-        } else {
-            options.insert(.ignoreMetacharacters)
+    private var annotatedText: String {
+        switch matchMethod {
+        case .fullWord:
+            return "\\b\(escapedText)\\b"
+        case .startsWith:
+            return "\\b\(escapedText)"
+        case .endsWith:
+            return "\(escapedText)\\b"
+        case .contains:
+            return escapedText
+        case .regularExpression:
+            return text
         }
+    }
+    private var escapedText: String {
+        return NSRegularExpression.escapedPattern(for: text)
+    }
+    private var regularExpressionOptions: NSRegularExpression.Options {
+        var options: NSRegularExpression.Options = [.anchorsMatchLines]
         if !isCaseSensitive {
             options.insert(.caseInsensitive)
         }
@@ -29,15 +55,24 @@ public struct SearchQuery: Hashable, Equatable {
     /// Creates a query to search for in the text view.
     /// - Parameters:
     ///   - text: The text to search for. May be a regular expression if `isRegularExpression` is `true`.
-    ///   - isRegularExpression: Whether the text is a regular exprssion.
+    ///   - matchMethod: Strategy to use when matching the search text against the text in the text view. Defaults to ``SearchQuery/MatchMethod/regularExpression``
     ///   - isCaseSensitive: Whether to perform a case-sensitive search.
-    public init(text: String, isRegularExpression: Bool = false, isCaseSensitive: Bool = false) {
+    public init(text: String, matchMethod: MatchMethod = .contains, isCaseSensitive: Bool = false) {
         self.text = text
-        self.isRegularExpression = isRegularExpression
+        self.matchMethod = matchMethod
         self.isCaseSensitive = isCaseSensitive
     }
 
-    func makeRegularExpression() throws -> NSRegularExpression {
-        return try NSRegularExpression(pattern: text, options: regularExpressionOptions)
+    func matches(in string: NSString) -> [NSTextCheckingResult] {
+        do {
+            let regex = try NSRegularExpression(pattern: annotatedText, options: regularExpressionOptions)
+            let range = NSRange(location: 0, length: string.length)
+            return regex.matches(in: string as String, range: range)
+        } catch {
+            #if DEBUG
+            print(error)
+            #endif
+            return []
+        }
     }
 }

--- a/Tests/RunestoneTests/SearchQueryTests.swift
+++ b/Tests/RunestoneTests/SearchQueryTests.swift
@@ -1,0 +1,53 @@
+@testable import Runestone
+import XCTest
+
+final class SearchQueryTests: XCTestCase {
+    private let sampleText: NSString = """
+/**
+ * This is a Runestone text view with syntax highlighting
+ * for the JavaScript programming language.
+ */
+
+let names = ["Steve Jobs", "Tim Cook", "Eddy Cue"]
+let years = [1955, 1960, 1964]
+printNamesAndYears(names, years)
+
+// Print the year each person was born.
+function printNamesAndYears(names, years) {
+  for (let i = 0; i < names.length; i++) {
+    console.log(names[i] + " was born in " + years[i])
+  }
+}
+"""
+
+    func testContainsMatchMethod() {
+        let searchQuery = SearchQuery(text: "names", matchMethod: .contains)
+        let ranges = searchQuery.matches(in: sampleText)
+        XCTAssertEqual(ranges.count, 7)
+    }
+
+    func testFullWordMatchMethod() {
+        let searchQuery = SearchQuery(text: "names", matchMethod: .fullWord)
+        let ranges = searchQuery.matches(in: sampleText)
+        XCTAssertEqual(ranges.count, 5)
+    }
+
+    func testStartsWithMatchMethod() {
+        let searchQuery = SearchQuery(text: "nam", matchMethod: .startsWith)
+        let ranges = searchQuery.matches(in: sampleText)
+        XCTAssertEqual(ranges.count, 5)
+    }
+
+    func testEndsWithMatchMethod() {
+        let searchQuery = SearchQuery(text: "rs", matchMethod: .endsWith)
+        let ranges = searchQuery.matches(in: sampleText)
+        XCTAssertEqual(ranges.count, 6)
+    }
+
+    func testRegularExpressionMatchMethod() {
+        // Matches strings containing the names.
+        let searchQuery = SearchQuery(text: "\"[A-Z][a-z]+ [A-Z][a-z]+\"", matchMethod: .regularExpression)
+        let ranges = searchQuery.matches(in: sampleText)
+        XCTAssertEqual(ranges.count, 3)
+    }
+}


### PR DESCRIPTION
This PR replaces the `isRegularExpression` property on SearchQuery with a `matchMethod` property. This property and the new MatchMethod enum can be used to specify the strategy to use when matching the search text against the text in the text view.

With this change Runestone now supports matching full words, the start of a word, and the end of a word.

**This is a breaking change** as the `isRegularExpression` property have been removed. Previously we could create a SearchQuery as follows:

```swift
let searchQuery = SearchQuery(text: someText, isRegularExpression: true)
```

This should be changed to use the regular expression match method instead.

```swift
let searchQuery = SearchQuery(text: someText, matchMethod: .regularExpression)
```