### PR TITLE
Only inserts text once when shifting left and right

### DIFF
--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -1487,11 +1487,15 @@ extension TextInputView: LayoutManagerDelegate {
 // MARK: - IndentControllerDelegate
 extension TextInputView: IndentControllerDelegate {
     func indentController(_ controller: IndentController, shouldInsert text: String, in range: NSRange) {
+        inputDelegate?.selectionWillChange(self)
         replaceText(in: range, with: text)
+        inputDelegate?.selectionDidChange(self)
     }
 
     func indentController(_ controller: IndentController, shouldSelect range: NSRange) {
+        inputDelegate?.selectionWillChange(self)
         selectedRange = range
+        inputDelegate?.selectionDidChange(self)
     }
 }
 


### PR DESCRIPTION
This PR improves the logic for shifting a selection left and right by ensuring that we only insert text once, at the cost of an increased memory usage.

This also fixes an issue where the selected range was not always properly reflected after shifting left or right.