### PR TITLE
Layout lines up to the specified line

### DIFF
--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -820,6 +820,7 @@ open class TextView: UIScrollView {
         resignFirstResponder()
         becomeFirstResponder()
         let line = textInputView.lineManager.line(atRow: lineIndex)
+        textInputView.layoutLines(toLocation: line.location)
         scroll(to: line.location)
         layoutIfNeeded()
         switch selection {


### PR DESCRIPTION
Fixes an issue where `goToLine(_:select:)` did not ensure that the lines were laid out up to the specified line.