### PR TITLE
Fixes incorrect range returned from -customRangeOfComposedCharacterSequences(for:)

### DIFF
--- a/Sources/Runestone/Library/NSString+Helpers.swift
+++ b/Sources/Runestone/Library/NSString+Helpers.swift
@@ -37,22 +37,12 @@ extension NSString {
     /// A wrapper around `rangeOfComposedCharacterSequences(for:)` that considers CRLF line endings as composed character sequences.
     func customRangeOfComposedCharacterSequences(for range: NSRange) -> NSRange {
         let defaultRange = rangeOfComposedCharacterSequences(for: range)
-        var resultingLocation = defaultRange.location
-        var resultingLength = defaultRange.length
-        if defaultRange.location > 0 && defaultRange.location < length - 1 {
-            let candidateCRLFRange = NSRange(location: defaultRange.location - 1, length: 2)
-            if isCRLFLineEnding(in: candidateCRLFRange) {
-                resultingLocation -= 1
-                resultingLength += 1
-            }
+        let candidateCRLFRange = NSRange(location: defaultRange.location - 1, length: 2)
+        if candidateCRLFRange.location >= 0 && candidateCRLFRange.upperBound <= length && isCRLFLineEnding(in: candidateCRLFRange) {
+            return candidateCRLFRange
+        } else {
+            return defaultRange
         }
-        if defaultRange.upperBound < length - 1 {
-            let candidateCRLFRange = NSRange(location: defaultRange.upperBound, length: 2)
-            if isCRLFLineEnding(in: candidateCRLFRange) {
-                resultingLength += 2
-            }
-        }
-        return NSRange(location: resultingLocation, length: resultingLength)
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where `-customRangeOfComposedCharacterSequences(for:)` returned incorrect ranges. The issue was introduced in bd650902683bcc1827a1a4b178f88ffc8881dea2.

The issue was evident when attempting to delete a CRLF line break as shown in the videos below.

**Before the fix**

https://user-images.githubusercontent.com/830995/179409731-fb4ee0c6-3873-49be-90e0-e1809dfb8280.mp4

**After the fix**

https://user-images.githubusercontent.com/830995/179410013-3a1066da-d481-4203-80b6-dce3bc1c19a7.mp4


