### PR TITLE
Add support for line break mode in TextView

### DIFF
--- a/Sources/Runestone/TextView/LineBreakMode.swift
+++ b/Sources/Runestone/TextView/LineBreakMode.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+ /// Line break mode for text view.
+ public enum LineBreakMode: Int, CaseIterable {
+     /// Wrap at word boundaries.
+     case byWordWrapping = 0
+     /// Wrap at character boundaries.
+     case byCharWrapping = 1
+ }

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -107,10 +107,10 @@ final class LineController {
         }
     }
 
-    init(line: DocumentLineNode, stringView: StringView) {
+    init(line: DocumentLineNode, stringView: StringView, lineBreakMode: LineBreakMode) {
         self.line = line
         self.stringView = stringView
-        self.typesetter = LineTypesetter(lineID: line.id.rawValue)
+        self.typesetter = LineTypesetter(lineID: line.id.rawValue, lineBreakMode: lineBreakMode)
         self.textInputProxy.estimatedLineFragmentHeight = estimatedLineFragmentHeight
         let rootLineFragmentNodeData = LineFragmentNodeData(lineFragment: nil)
         self.lineFragmentTree = LineFragmentTree(minimumValue: 0, rootValue: 0, rootData: rootLineFragmentNodeData)

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -75,6 +75,14 @@ final class LineController {
             }
         }
     }
+    var lineBreakMode: LineBreakMode {
+        get {
+            return typesetter.lineBreakMode
+        }
+        set {
+            typesetter.lineBreakMode = newValue
+        }
+    }
     var numberOfLineFragments: Int {
         return typesetter.lineFragments.count
     }
@@ -107,10 +115,10 @@ final class LineController {
         }
     }
 
-    init(line: DocumentLineNode, stringView: StringView, lineBreakMode: LineBreakMode) {
+    init(line: DocumentLineNode, stringView: StringView) {
         self.line = line
         self.stringView = stringView
-        self.typesetter = LineTypesetter(lineID: line.id.rawValue, lineBreakMode: lineBreakMode)
+        self.typesetter = LineTypesetter(lineID: line.id.rawValue)
         self.textInputProxy.estimatedLineFragmentHeight = estimatedLineFragmentHeight
         let rootLineFragmentNodeData = LineFragmentNodeData(lineFragment: nil)
         self.lineFragmentTree = LineFragmentTree(minimumValue: 0, rootValue: 0, rootData: rootLineFragmentNodeData)

--- a/Sources/Runestone/TextView/LineController/LineTypesetter.swift
+++ b/Sources/Runestone/TextView/LineController/LineTypesetter.swift
@@ -51,6 +51,7 @@ final class LineTypesetter {
     }
 
     private let lineID: String
+    private var lineBreakMode: LineBreakMode
     private var stringLength = 0
     private var attributedString: NSAttributedString?
     private var typesetter: CTTypesetter?
@@ -59,8 +60,9 @@ final class LineTypesetter {
     private var nextYPosition: CGFloat = 0
     private var lineFragmentIndex = 0
 
-    init(lineID: String) {
+    init(lineID: String, lineBreakMode: LineBreakMode) {
         self.lineID = lineID
+        self.lineBreakMode = lineBreakMode
     }
 
     func reset() {
@@ -179,26 +181,43 @@ private extension LineTypesetter {
     }
 
     private func suggestNextLineBreak(using typesetter: CTTypesetter) -> Int {
-        let length = CTTypesetterSuggestLineBreak(typesetter, startOffset, Double(constrainingWidth))
-        guard startOffset + length < stringLength else {
-            // We've reached the end of the line.
-            return length
-        }
-        let lastCharacterIndex = startOffset + length - 1
-        let prefersLineBreakAfterCharacter = prefersInsertingLineBreakAfterCharacter(at: lastCharacterIndex)
-        guard !prefersLineBreakAfterCharacter else {
-            // We're breaking at a whitespace so we return the break suggested by CTTypesetter.
-            return length
-        }
-        // CTTypesetter did not suggest breaking at a whitespace. We try to go back in the string to find a whitespace to break at.
-        // If that fails we'll just use the break suggested by CTTypesetter. This workaround solves two issues:
-        // 1. The results more closely matches the behavior of desktop editors like Nova. They tend to prefer breaking at whitespaces.
-        // 2. It fixes an issue where breaking in the middle of the /> ligature would cause the slash not to be drawn. More info in this tweet:
-        //    https://twitter.com/simonbs/status/1515961709671899137
-        let maximumLookback = min(length, 100)
-        if let lookbackLength = lookbackToFindFirstLineBreakableCharacter(startingAt: startOffset + length, maximumLookback: maximumLookback) {
-            return length - lookbackLength
-        } else {
+        let length: CFIndex
+        switch lineBreakMode {
+        case .byWordWrapping:
+            length = CTTypesetterSuggestLineBreak(typesetter, startOffset, Double(constrainingWidth))
+            guard startOffset + length < stringLength else {
+                // We've reached the end of the line.
+                return length
+            }
+            let lastCharacterIndex = startOffset + length - 1
+            let prefersLineBreakAfterCharacter = prefersInsertingLineBreakAfterCharacter(at: lastCharacterIndex)
+            guard !prefersLineBreakAfterCharacter else {
+                // We're breaking at a whitespace so we return the break suggested by CTTypesetter.
+                return length
+            }
+            // CTTypesetter did not suggest breaking at a whitespace. We try to go back in the string to find a whitespace to break at.
+            // If that fails we'll just use the break suggested by CTTypesetter. This workaround solves two issues:
+            // 1. The results more closely matches the behavior of desktop editors like Nova. They tend to prefer breaking at whitespaces.
+            // 2. It fixes an issue where breaking in the middle of the /> ligature would cause the slash not to be drawn. More info in this tweet:
+            //    https://twitter.com/simonbs/status/1515961709671899137
+            let maximumLookback = min(length, 100)
+            if let lookbackLength = lookbackToFindFirstLineBreakableCharacter(startingAt: startOffset + length, maximumLookback: maximumLookback) {
+                return length - lookbackLength
+            } else {
+                return length
+            }
+        case .byCharWrapping:
+            length = CTTypesetterSuggestClusterBreak(typesetter, startOffset, Double(constrainingWidth))
+            guard startOffset + length < stringLength, let attributedString = attributedString else {
+                // There is no character after suggested line break.
+                return length
+            }
+            let lastCharacterIndex = startOffset + length - 1
+            let range = NSRange(location: lastCharacterIndex, length: 2)
+            if attributedString.attributedSubstring(from: range).string == Symbol.carriageReturnLineFeed {
+                // Suggested line break is in the middle of CRLF so return one position ahead which is after the character pair.
+                return length + 1
+            }
             return length
         }
     }

--- a/Sources/Runestone/TextView/LineController/LineTypesetter.swift
+++ b/Sources/Runestone/TextView/LineController/LineTypesetter.swift
@@ -178,7 +178,7 @@ private extension LineTypesetter {
         }
         return lineFragment
     }
-    
+
     private func suggestNextLineBreak(using typesetter: CTTypesetter) -> Int {
         switch lineBreakMode {
         case .byWordWrapping:
@@ -227,7 +227,7 @@ private extension LineTypesetter {
         }
         return length
     }
-    
+
     private func lookbackToFindFirstLineBreakableCharacter(startingAt startLocation: Int, maximumLookback: Int) -> Int? {
         var lookback = 0
         var foundWhitespace = false

--- a/Sources/Runestone/TextView/LineController/LineTypesetter.swift
+++ b/Sources/Runestone/TextView/LineController/LineTypesetter.swift
@@ -181,10 +181,9 @@ private extension LineTypesetter {
     }
 
     private func suggestNextLineBreak(using typesetter: CTTypesetter) -> Int {
-        let length: CFIndex
         switch lineBreakMode {
         case .byWordWrapping:
-            length = CTTypesetterSuggestLineBreak(typesetter, startOffset, Double(constrainingWidth))
+            let length = CTTypesetterSuggestLineBreak(typesetter, startOffset, Double(constrainingWidth))
             guard startOffset + length < stringLength else {
                 // We've reached the end of the line.
                 return length
@@ -207,7 +206,7 @@ private extension LineTypesetter {
                 return length
             }
         case .byCharWrapping:
-            length = CTTypesetterSuggestClusterBreak(typesetter, startOffset, Double(constrainingWidth))
+            let length = CTTypesetterSuggestClusterBreak(typesetter, startOffset, Double(constrainingWidth))
             guard startOffset + length < stringLength, let attributedString = attributedString else {
                 // There is no character after suggested line break.
                 return length

--- a/Sources/Runestone/TextView/TextInput/LayoutManager.swift
+++ b/Sources/Runestone/TextView/TextInput/LayoutManager.swift
@@ -392,6 +392,7 @@ final class LayoutManager {
             lineController.lineFragmentHeightMultiplier = lineHeightMultiplier
             lineController.tabWidth = tabWidth
             lineController.kern = kern
+            lineController.lineBreakMode = lineBreakMode
             lineController.invalidateSyntaxHighlighting()
         }
     }
@@ -907,13 +908,14 @@ extension LayoutManager {
         if let cachedLineController = lineControllers[line.id] {
             return cachedLineController
         } else {
-            let lineController = LineController(line: line, stringView: stringView, lineBreakMode: lineBreakMode)
+            let lineController = LineController(line: line, stringView: stringView)
             lineController.delegate = self
             lineController.constrainingWidth = constrainingLineWidth
             lineController.estimatedLineFragmentHeight = theme.font.totalLineHeight
             lineController.lineFragmentHeightMultiplier = lineHeightMultiplier
             lineController.tabWidth = tabWidth
             lineController.theme = theme
+            lineController.lineBreakMode = lineBreakMode
             lineControllers[line.id] = lineController
             return lineController
         }

--- a/Sources/Runestone/TextView/TextInput/LayoutManager.swift
+++ b/Sources/Runestone/TextView/TextInput/LayoutManager.swift
@@ -130,6 +130,14 @@ final class LayoutManager {
             }
         }
     }
+    var lineBreakMode: LineBreakMode = .byWordWrapping {
+         didSet {
+             if lineBreakMode != oldValue {
+                 invalidateContentSize()
+                 invalidateLines()
+             }
+         }
+     }
     /// Leading padding inside the gutter.
     var gutterLeadingPadding: CGFloat = 3 {
         didSet {
@@ -899,7 +907,7 @@ extension LayoutManager {
         if let cachedLineController = lineControllers[line.id] {
             return cachedLineController
         } else {
-            let lineController = LineController(line: line, stringView: stringView)
+            let lineController = LineController(line: line, stringView: stringView, lineBreakMode: lineBreakMode)
             lineController.delegate = self
             lineController.constrainingWidth = constrainingLineWidth
             lineController.estimatedLineFragmentHeight = theme.font.totalLineHeight

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -317,6 +317,20 @@ final class TextInputView: UIView, UITextInput {
             }
         }
     }
+    var lineBreakMode: LineBreakMode {
+        get {
+            return layoutManager.lineBreakMode
+        }
+        set {
+            if newValue != layoutManager.lineBreakMode {
+                layoutManager.lineBreakMode = newValue
+                layoutManager.invalidateLines()
+                layoutManager.setNeedsLayout()
+                layoutManager.layoutIfNeeded()
+                sendSelectionChangedToTextSelectionView()
+            }
+        }
+    }
     var gutterWidth: CGFloat {
         return layoutManager.gutterWidth
     }

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -430,6 +430,15 @@ open class TextView: UIScrollView {
             textInputView.isLineWrappingEnabled = newValue
         }
     }
+    /// Line break mode for text view. The default value is .byWordWrapping meaning that wrapping occurs on word boundaries.
+    public var lineBreakMode: LineBreakMode {
+        get {
+            return textInputView.lineBreakMode
+        }
+        set {
+            textInputView.lineBreakMode = newValue
+        }
+    }
     /// Width of the gutter.
     public var gutterWidth: CGFloat {
         return textInputView.gutterWidth


### PR DESCRIPTION
Add a new LineBreakMode type and use it to expose a setting to user to set line break mode. Pass line break mode setting to LayoutManager, LineController and LineTypesetter to look for line breaks using CTTypesetterSuggestClusterBreak instead of CTTypesetterSuggestLineBreak when wrapping lines by character.