### PR TITLE
Improves timing when notifying input delegate of selection changes (Thanks Alexander Blach (@blach)!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ The Runestone framework is used by an app of the same name. The Runestone app is
 
 <a href="https://apps.apple.com/us/app/runestone-editor/id1548193893" target="_blank"><img width="150" alt="Download on the App Store" src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"/></a>
 
+## 👨‍💻 Contributing
+
+Pull requests with bugfixes and new features are much appreciated. I'll be happy to review them and merge them once they're ready, as long as they contain change that fit within the vision of Runestone and provide generally useful functionality.
+
+Clone the repository to get started working on the project. Note that Runestone depends on Tree-sitter through a submodule. This submodule must be cloned as well before Runestone can be built. Pass the `--recursive` option when cloning the repository to clone all submodules.
+
+```bash
+git clone --recursive git@github.com:simonbs/Runestone.git
+```
+
 ## ❤️ Acknowledgments
 
 - [Tree-sitter](https://tree-sitter.github.io/tree-sitter) is used to parse code incrementally.

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -541,6 +541,7 @@ final class TextInputView: UIView, UITextInput {
     }
     private var hasPendingFullLayout = false
     private let editMenuController = EditMenuController()
+    // swiftlint:disable:next identifier_name
     private var shouldNotifyInputDelegateAboutSelectionChangeInLayoutSubviews = false
 
     // MARK: - Lifecycle

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -313,7 +313,6 @@ final class TextInputView: UIView, UITextInput {
                 layoutManager.invalidateLines()
                 layoutManager.setNeedsLayout()
                 layoutManager.layoutIfNeeded()
-                sendSelectionChangedToTextSelectionView()
             }
         }
     }
@@ -327,7 +326,6 @@ final class TextInputView: UIView, UITextInput {
                 layoutManager.invalidateLines()
                 layoutManager.setNeedsLayout()
                 layoutManager.layoutIfNeeded()
-                sendSelectionChangedToTextSelectionView()
             }
         }
     }
@@ -995,7 +993,6 @@ extension TextInputView {
             timedUndoManager.beginUndoGrouping()
         }
         replaceText(in: deleteRange, with: "", selectedRangeAfterUndo: selectedRangeAfterUndo)
-        sendSelectionChangedToTextSelectionView()
         if isDeletingMultipleCharacters {
             timedUndoManager.endUndoGrouping()
         }
@@ -1169,26 +1166,6 @@ extension TextInputView {
         let cappedLocation = min(max(range.location, 0), stringView.string.length)
         let cappedLength = min(max(range.length, 0), stringView.string.length - cappedLocation)
         return NSRange(location: cappedLocation, length: cappedLength)
-    }
-
-    func sendSelectionChangedToTextSelectionView() {
-        // Fores the position of the caret to be updated. Normally we can do this by notifying the input delegate when changing the selected range like:
-        //
-        // inputDelegate?.selectionWillChange(self)
-        // selectedRange = newSelectedRange
-        // inputDelegate?.selectionDidChange(self)
-        //
-        // If we don't notify the input delegate when the setter on selectedTextRange is called, then the location of the caret will not be updated.
-        // However, if we do notify the delegate when the setter is called, Korean input will no longer work as described in https://github.com/simonbs/Runestone/issues/11
-        // So the workaround is to not notify the delegate but tell the text selection view directly that the selection has changed.
-        if let textSelectionView = textSelectionView {
-            let sel = NSSelectorFromString("selectionChanged")
-            if textSelectionView.responds(to: sel) {
-                textSelectionView.perform(sel)
-            } else {
-                print("\(textSelectionView) does not respond to 'selectionChanged'")
-            }
-        }
     }
 
     private func moveCaret(to linePosition: LinePosition) {

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -733,9 +733,9 @@ open class TextView: UIScrollView {
     /// Inserts text at the location of the caret or, if no selection or caret is present, at the end of the text.
     /// - Parameter text: A string to insert.
     open func insertText(_ text: String) {
+        textInputView.inputDelegate?.selectionWillChange(textInputView)
         textInputView.insertText(text)
-        // Called in TextView since we only want to force the text selection view to update when editing text programmatically.
-        textInputView.sendSelectionChangedToTextSelectionView()
+        textInputView.inputDelegate?.selectionDidChange(textInputView)
     }
 
     /// Replaces the text that is in the specified range.
@@ -743,9 +743,9 @@ open class TextView: UIScrollView {
     ///   - range: A range of text in the document.
     ///   - text: A string to replace the text in range.
     open func replace(_ range: UITextRange, withText text: String) {
+        textInputView.inputDelegate?.selectionWillChange(textInputView)
         textInputView.replace(range, withText: text)
-        // Called in TextView since we only want to force the text selection view to update when editing text programmatically.
-        textInputView.sendSelectionChangedToTextSelectionView()
+        textInputView.inputDelegate?.selectionDidChange(textInputView)
     }
 
     /// Replaces the text that is in the specified range.
@@ -753,10 +753,10 @@ open class TextView: UIScrollView {
     ///   - range: A range of text in the document.
     ///   - text: A string to replace the text in range.
     public func replace(_ range: NSRange, withText text: String) {
+        textInputView.inputDelegate?.selectionWillChange(textInputView)
         let indexedRange = IndexedRange(range)
         textInputView.replace(indexedRange, withText: text)
-        // Called in TextView since we only want to force the text selection view to update when editing text programmatically.
-        textInputView.sendSelectionChangedToTextSelectionView()
+        textInputView.inputDelegate?.selectionDidChange(textInputView)
     }
 
     /// Replaces the text in the specified matches.

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -584,7 +584,7 @@ open class TextView: UIScrollView {
     private let tapGestureRecognizer = QuickTapGestureRecognizer()
     private var _inputAccessoryView: UIView?
     private let _inputAssistantItem = UITextInputAssistantItem()
-    private var willBeginEditingFromNonEditableTextInteraction = false
+    private var isPerformingNonEditableTextInteraction = false
     private var delegateAllowsEditingToBegin: Bool {
         guard isEditable else {
             return false
@@ -671,8 +671,6 @@ open class TextView: UIScrollView {
     @discardableResult
     override open func becomeFirstResponder() -> Bool {
         if !isEditing && delegateAllowsEditingToBegin {
-            // Reset willBeginEditingFromNonEditableTextInteraction to support calling becomeFirstResponder() programmatically.
-            willBeginEditingFromNonEditableTextInteraction = false
             _ = textInputView.resignFirstResponder()
             _ = textInputView.becomeFirstResponder()
             return true
@@ -1079,7 +1077,6 @@ private extension TextView {
             return
         }
         if gestureRecognizer.state == .ended {
-            willBeginEditingFromNonEditableTextInteraction = false
             let point = gestureRecognizer.location(in: textInputView)
             let oldSelectedRange = textInputView.selectedRange
             textInputView.moveCaret(to: point)
@@ -1240,10 +1237,10 @@ extension TextView: TextInputViewDelegate {
         guard isEditable else {
             return
         }
-        isEditing = !willBeginEditingFromNonEditableTextInteraction
+        isEditing = !isPerformingNonEditableTextInteraction
         // If a developer is programmatically calling becomeFirstresponder() then we might not have a selected range.
         // We set the selectedRange instead of the selectedTextRange to avoid invoking any delegates.
-        if textInputView.selectedRange == nil && !willBeginEditingFromNonEditableTextInteraction {
+        if textInputView.selectedRange == nil && !isPerformingNonEditableTextInteraction {
             textInputView.selectedRange = NSRange(location: 0, length: 0)
         }
         // Ensure selection is laid out without animation.
@@ -1251,13 +1248,13 @@ extension TextView: TextInputViewDelegate {
             textInputView.layoutIfNeeded()
         }
         // The editable interaction must be installed early in the -becomeFirstResponder() call
-        if !willBeginEditingFromNonEditableTextInteraction {
+        if !isPerformingNonEditableTextInteraction {
             installEditableInteraction()
         }
     }
 
     func textInputViewDidBeginEditing(_ view: TextInputView) {
-        if !willBeginEditingFromNonEditableTextInteraction {
+        if !isPerformingNonEditableTextInteraction {
             editorDelegate?.textViewDidBeginEditing(self)
         }
     }
@@ -1425,7 +1422,13 @@ extension TextView: UITextInteractionDelegate {
             // When long-pressing our instance of UITextInput, the UITextInteraction will make the text input first responder.
             // In this case the user wants to select text in the text view but not start editing, so we set a flag that tells us
             // that we should not install editable text interaction in this case.
-            willBeginEditingFromNonEditableTextInteraction = true
+            isPerformingNonEditableTextInteraction = true
+        }
+    }
+
+    public func interactionDidEnd(_ interaction: UITextInteraction) {
+        if interaction.textInteractionMode == .nonEditable {
+            isPerformingNonEditableTextInteraction = false
         }
     }
 }


### PR DESCRIPTION
TextInputView notifies the input delegate of selection changes using the `-selectionWillChange(_:)` and `-selectionDidChange(_:)`.

However, these functions shouldn't be called every time the selection changes. When entering Korean input, UIKit may assign a new value to `selectedTextRange` and shortly after call `deleteBackwards()` to delete the selected range. This is done to delete previous characters and replace them with a single character. This operation will not be performed correctly if we notify the input delegate of selection changes when UIKit calls `selectedTextRange` at this time.

To workaround this, we never notify the input delegate of selection changes when a new value is assigned to `selectedTextRange `. Instead we notify the delegate in `layoutSubviews()`. However, we don't do that when `deleteBackwards()` is called. Instead, we manually call `-selectionWillChange(_:)` and `-selectionDidChange(_:)` in `deleteBackwards()`. This ensures proper timing.

When testing this there are at least the following cases we'd like to test:

1. Inserting and deleting characters correctly moves the caret.
2. Navigating the text with arrow keys.
3. The location of the correct is correctly updated when working with marked text, e.g. when inserting a backtick (`) and then deleting it, adding more characters, or navigating away from it with the arrow keys.
4. Inserting Korean text where multiple characters are replaced with a single character as we're typing.
5. The location of the caret is correctly updated when inserting text programmatically via `insertText(_:)` on an instance of TextView.
6. The location of the caret is correctly updated when shifting text left and right using `shiftLeft()` and `shiftRight()` on an instance of TextView.
7. That the location of the caret is correctly updated when undoing and redoing changes.

Thanks a lot to Alexander Blach ([@blach](https://github.com/blach), [@lextar](https://twitter.com/lextar)), developer of [Textastic](https://apps.apple.com/us/app/textastic-code-editor/id1049254261), for assisting with these changes.