### PR TITLE
Only redisplays visible lines

### DIFF
--- a/Sources/Runestone/TextView/TextInput/LayoutManager.swift
+++ b/Sources/Runestone/TextView/TextInput/LayoutManager.swift
@@ -412,10 +412,13 @@ final class LayoutManager {
     func redisplayLines(withIDs lineIDs: Set<DocumentLineNodeID>) {
         for lineID in lineIDs {
             if let lineController = lineControllers[lineID] {
-                let lineYPosition = lineController.line.yPosition
-                let lineLocalViewport = CGRect(x: 0, y: lineYPosition, width: insetViewport.width, height: insetViewport.maxY - lineYPosition)
                 lineController.invalidateEverything()
-                lineController.prepareToDisplayString(in: lineLocalViewport, syntaxHighlightAsynchronously: false)
+                // Only display the line if it's currently visible on the screen. Otherwise it's enough to invalidate it and redisplay it later.
+                if visibleLineIDs.contains(lineID) {
+                    let lineYPosition = lineController.line.yPosition
+                    let lineLocalViewport = CGRect(x: 0, y: lineYPosition, width: insetViewport.width, height: insetViewport.maxY - lineYPosition)
+                    lineController.prepareToDisplayString(in: lineLocalViewport, syntaxHighlightAsynchronously: false)
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixes #132. Runestone would block the main thread for unnecessarily long when the following events happened:

1. The user edits the text.
2. Runestone updates Tree-sitter's tree with the changes.
3. Tree-sitter returns the edited range in the tree.
4. Runestone redisplays all edited lines, and as such syntax highlights all edited lines.

In some cases Tree-sitter may report that thousands of lines (specifically ~1.800 lines in the example in #132) were edited. However, only few of those lines were visible on the screen and as such it's unnecessary to syntax highlight all 1.800 lines.

The fix is to invalidate all edited lines but only syntax highlight those that are actually visible on the screen. Lines that aren't visible on the screen are updated once they're scrolled onto the screen.