### PR TITLE
API: convert row/column to offset

### DIFF
--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -724,7 +724,7 @@ open class TextView: UIScrollView {
     /// Returns the relative location to the first index in the text for the row/column text location.
     /// - Parameter textLocation: The row/column text location in the text.
     /// - Returns: The location if the input text location could be found in the string, otherwise nil.
-    public func textLocation(at textLocation: TextLocation) -> Int? {
+    public func location(at textLocation: TextLocation) -> Int? {
         let lineIndex = textLocation.lineNumber
         guard lineIndex >= 0 && lineIndex < textInputView.lineManager.lineCount else {
             return nil

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -720,6 +720,21 @@ open class TextView: UIScrollView {
             return nil
         }
     }
+    
+    /// Returns the relative location to the first index in the text for the row/column text location.
+    /// - Parameter textLocation: The row/column text location in the text.
+    /// - Returns: The location if the input text location could be found in the string, otherwise nil.
+    public func textLocation(at textLocation: TextLocation) -> Int? {
+        let lineIndex = textLocation.lineNumber
+        guard lineIndex >= 0 && lineIndex < textInputView.lineManager.lineCount else {
+            return nil
+        }
+        let line = textInputView.lineManager.line(atRow: lineIndex)
+        guard textLocation.column >= 0 && textLocation.column <= line.data.totalLength else {
+            return nil
+        }
+        return line.location + textLocation.column
+    }
 
     /// Sets the language mode on a background thread.
     ///

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -721,9 +721,9 @@ open class TextView: UIScrollView {
         }
     }
 
-    /// Returns the relative location to the first index in the text for the row/column text location.
-    /// - Parameter textLocation: The row/column text location in the text.
-    /// - Returns: The location if the input text location could be found in the string, otherwise nil.
+    /// Returns the character location at the specified row and column.
+    /// - Parameter textLocation: The row and column in the text.
+    /// - Returns: The location if the input row and column could be found in the text, otherwise nil.
     public func location(at textLocation: TextLocation) -> Int? {
         let lineIndex = textLocation.lineNumber
         guard lineIndex >= 0 && lineIndex < textInputView.lineManager.lineCount else {

--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -720,7 +720,7 @@ open class TextView: UIScrollView {
             return nil
         }
     }
-    
+
     /// Returns the relative location to the first index in the text for the row/column text location.
     /// - Parameter textLocation: The row/column text location in the text.
     /// - Returns: The location if the input text location could be found in the string, otherwise nil.


### PR DESCRIPTION
Fix #137 

Add an override for `func textLocation(at)` to support converting row/column (`TextLocation`) to offset (`Int`). This makes it possible to convert a row/column position to a location on `NSString`.