### PR TITLE
Treats punctuation characters as word boundaries

### DIFF
--- a/Sources/Runestone/TextView/TextInput/TextInputStringTokenizer.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputStringTokenizer.swift
@@ -85,4 +85,3 @@ private extension TextInputStringTokenizer {
         return direction.rawValue == UITextStorageDirection.forward.rawValue || direction.rawValue == UITextLayoutDirection.right.rawValue
     }
 }
-

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -64,7 +64,10 @@ final class TextInputView: UIView, UITextInput {
     var hasText: Bool {
         return string.length > 0
     }
-    private(set) lazy var tokenizer: UITextInputTokenizer = TextInputStringTokenizer(textInput: self, lineManager: lineManager, stringView: stringView)
+    private(set) lazy var tokenizer: UITextInputTokenizer = TextInputStringTokenizer(
+        textInput: self,
+        lineManager: lineManager,
+        stringView: stringView)
     var autocorrectionType: UITextAutocorrectionType = .default
     var autocapitalizationType: UITextAutocapitalizationType = .sentences
     var smartQuotesType: UITextSmartQuotesType = .default

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -64,7 +64,7 @@ final class TextInputView: UIView, UITextInput {
     var hasText: Bool {
         return string.length > 0
     }
-    private(set) lazy var tokenizer: UITextInputTokenizer = TextInputStringTokenizer(textInput: self, lineManager: lineManager)
+    private(set) lazy var tokenizer: UITextInputTokenizer = TextInputStringTokenizer(textInput: self, lineManager: lineManager, stringView: stringView)
     var autocorrectionType: UITextAutocorrectionType = .default
     var autocapitalizationType: UITextAutocapitalizationType = .sentences
     var smartQuotesType: UITextSmartQuotesType = .default


### PR DESCRIPTION
This PR makes it easier to move the caret next to punctuation characters, such as within two brackets.

https://user-images.githubusercontent.com/830995/182629489-07f96cb4-4ff1-4aff-8775-a9f50cba883a.MP4