### PR TITLE
Clears undo stack when setting string

### DIFF
--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -422,6 +422,9 @@ final class TextInputView: UIView, UITextInput {
                 layoutManager.invalidateLines()
                 layoutManager.setNeedsLayout()
                 layoutManager.layoutIfNeeded()
+                if !shouldPreserveUndoStackWhenSettingString {
+                    undoManager?.removeAllActions()
+                }
             }
         }
     }
@@ -546,6 +549,7 @@ final class TextInputView: UIView, UITextInput {
     private let editMenuController = EditMenuController()
     // swiftlint:disable:next identifier_name
     private var shouldNotifyInputDelegateAboutSelectionChangeInLayoutSubviews = false
+    private var shouldPreserveUndoStackWhenSettingString = false
 
     // MARK: - Lifecycle
     init(theme: Theme) {
@@ -1052,7 +1056,9 @@ extension TextInputView {
         }
         timedUndoManager.endUndoGrouping()
         let oldSelectedRange = selectedRange
+        shouldPreserveUndoStackWhenSettingString = true
         string = newString
+        shouldPreserveUndoStackWhenSettingString = false
         timedUndoManager.beginUndoGrouping()
         timedUndoManager.setActionName(L10n.Undo.ActionName.replaceAll)
         timedUndoManager.registerUndo(withTarget: self) { textInputView in


### PR DESCRIPTION
This PR aligns TextView's behavior with UITextView. When setting the `text` property on UITextView, the undo/redo stack will be cleared and with this PR TextView will do the same.