### PR TITLE
Sets correct selected range when editing marked text

### DIFF
--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -1291,8 +1291,11 @@ extension TextInputView {
         guard shouldChangeText(in: range, replacementText: markedText) else {
             return
         }
+        shouldNotifyInputDelegateAboutSelectionChangeInLayoutSubviews = true
         markedRange = markedText.isEmpty ? nil : NSRange(location: range.location, length: markedText.utf16.count)
         replaceText(in: range, with: markedText)
+        // The selected range passed to setMarkedText(_:selectedRange:) is local to the marked range.
+        _selectedRange = NSRange(location: range.location + selectedRange.location, length: selectedRange.length)
         delegate?.textInputViewDidUpdateMarkedRange(self)
     }
 


### PR DESCRIPTION
This PR fixes an issue where the selected range wasn't correctly updated when editing marked text. Specifically, the following two issues are fixed. The PR fixes #142.

1. The location of the caret is properly updated to match the value of `selectedRange` by setting `shouldNotifyInputDelegateAboutSelectionChangeInLayoutSubviews = true` when editing the marked text.
2. The `selectedRange` parameter is used when updating the selected range to ensure it matches the expected value of UIKit.

The following two videos show the behavior before and after the update.

**Before the update**

https://user-images.githubusercontent.com/830995/184644847-5f504a52-1f62-4cf3-96d5-a9c43ca7c8b4.mp4

**After the update**

https://user-images.githubusercontent.com/830995/184644877-dd76c285-5762-44eb-a685-03bea14dfdb0.mp4