### PR TITLE
Places the caret correctly when navigating between lines

### DIFF
--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -35,8 +35,20 @@ final class TextInputView: UIView, UITextInput {
             // It'll invoke the setter in various scenarios, for example when navigating the text using the keyboard.
             let newRange = (newValue as? IndexedRange)?.range
             if newRange != _selectedRange {
-                shouldNotifyInputDelegateAboutSelectionChangeInLayoutSubviews = true
+                // The logic for determining whether or not to notify the input delegate is based on advice provided by Alexander Blach, developer of Textastic.
+                var shouldNotifyInputDelegate = false
+                if didCallPositionFromPositionInDirectionWithOffset {
+                    shouldNotifyInputDelegate = true
+                    didCallPositionFromPositionInDirectionWithOffset = false
+                }
+                shouldNotifyInputDelegateAboutSelectionChangeInLayoutSubviews = !shouldNotifyInputDelegate
+                if shouldNotifyInputDelegate {
+                    inputDelegate?.selectionWillChange(self)
+                }
                 _selectedRange = newRange
+                if shouldNotifyInputDelegate {
+                    inputDelegate?.selectionDidChange(self)
+                }
                 delegate?.textInputViewDidChangeSelection(self)
             }
         }
@@ -551,6 +563,7 @@ final class TextInputView: UIView, UITextInput {
     private let editMenuController = EditMenuController()
     // swiftlint:disable:next identifier_name
     private var shouldNotifyInputDelegateAboutSelectionChangeInLayoutSubviews = false
+    private var didCallPositionFromPositionInDirectionWithOffset = false
     private var shouldPreserveUndoStackWhenSettingString = false
 
     // MARK: - Lifecycle
@@ -1330,6 +1343,7 @@ extension TextInputView {
         guard let indexedPosition = position as? IndexedPosition else {
             return nil
         }
+        didCallPositionFromPositionInDirectionWithOffset = true
         guard let location = lineMovementController.location(from: indexedPosition.index, in: direction, offset: offset) else {
             return nil
         }


### PR DESCRIPTION
This PR fixes a regression introduced in #129. Where the caret would not be placed correctly when navigating between lines or line fragments using the up and down arrow keys.

The video below shows the updated and correct behavior. Notice that the caret maintains the placement on each line and line fragment when possible and in other cases moves to the end of the line or line fragment.

https://user-images.githubusercontent.com/830995/187026600-a6b6b0f8-6eae-427c-8f95-ad0bf94a1c57.mp4