### PR TITLE
Fixes width of selection rects

### DIFF
--- a/Sources/Runestone/TextView/TextInput/LayoutManager.swift
+++ b/Sources/Runestone/TextView/TextInput/LayoutManager.swift
@@ -452,10 +452,10 @@ extension LayoutManager {
         let adjustedRange = NSRange(location: range.location, length: selectsLineEnding ? range.length - 1 : range.length)
         let startCaretRect = caretRect(at: adjustedRange.lowerBound)
         let endCaretRect = caretRect(at: adjustedRange.upperBound)
-        let fullWidth = max(contentWidth, scrollViewWidth) - textContainerInset.right
+        let fullWidth = max(contentWidth, scrollViewWidth) - leadingLineSpacing - textContainerInset.right
         if startCaretRect.minY == endCaretRect.minY && startCaretRect.maxY == endCaretRect.maxY {
             // Selecting text in the same line fragment.
-            let width = selectsLineEnding ? fullWidth - leadingLineSpacing : endCaretRect.maxX - startCaretRect.maxX
+            let width = selectsLineEnding ? fullWidth - (startCaretRect.minX - leadingLineSpacing) : endCaretRect.maxX - startCaretRect.maxX
             let scaledHeight = startCaretRect.height * lineHeightMultiplier
             let offsetY = startCaretRect.minY - (scaledHeight - startCaretRect.height) / 2
             let rect = CGRect(x: startCaretRect.minX, y: offsetY, width: width, height: scaledHeight)
@@ -463,15 +463,15 @@ extension LayoutManager {
             return [selectionRect]
         } else {
             // Selecting text across line fragments and possibly across lines.
-            let startWidth = fullWidth - startCaretRect.minX
+            let startWidth = fullWidth - (startCaretRect.minX - leadingLineSpacing)
             let startScaledHeight = startCaretRect.height * lineHeightMultiplier
             let startOffsetY = startCaretRect.minY - (startScaledHeight - startCaretRect.height) / 2
             let startRect = CGRect(x: startCaretRect.minX, y: startOffsetY, width: startWidth, height: startScaledHeight)
-            let endWidth = selectsLineEnding ? fullWidth - leadingLineSpacing : endCaretRect.minX - leadingLineSpacing
+            let endWidth = selectsLineEnding ? fullWidth  : endCaretRect.minX - leadingLineSpacing
             let endScaledHeight = endCaretRect.height * lineHeightMultiplier
             let endOffsetY = endCaretRect.minY - (endScaledHeight - endCaretRect.height) / 2
             let endRect = CGRect(x: leadingLineSpacing, y: endOffsetY, width: endWidth, height: endScaledHeight)
-            let middleWidth = fullWidth - leadingLineSpacing
+            let middleWidth = fullWidth
             let middleHeight = endRect.minY - startRect.maxY
             let middleRect = CGRect(x: leadingLineSpacing, y: startRect.maxY, width: middleWidth, height: middleHeight)
             let startSelectionRect = TextSelectionRect(rect: startRect, writingDirection: .natural, containsStart: true, containsEnd: false)

--- a/Sources/Runestone/TextView/TextInput/LayoutManager.swift
+++ b/Sources/Runestone/TextView/TextInput/LayoutManager.swift
@@ -471,9 +471,8 @@ extension LayoutManager {
             let endScaledHeight = endCaretRect.height * lineHeightMultiplier
             let endOffsetY = endCaretRect.minY - (endScaledHeight - endCaretRect.height) / 2
             let endRect = CGRect(x: leadingLineSpacing, y: endOffsetY, width: endWidth, height: endScaledHeight)
-            let middleWidth = fullWidth
             let middleHeight = endRect.minY - startRect.maxY
-            let middleRect = CGRect(x: leadingLineSpacing, y: startRect.maxY, width: middleWidth, height: middleHeight)
+            let middleRect = CGRect(x: leadingLineSpacing, y: startRect.maxY, width: fullWidth, height: middleHeight)
             let startSelectionRect = TextSelectionRect(rect: startRect, writingDirection: .natural, containsStart: true, containsEnd: false)
             let middleSelectionRect = TextSelectionRect(rect: middleRect, writingDirection: .natural, containsStart: false, containsEnd: false)
             let endSelectionRect = TextSelectionRect(rect: endRect, writingDirection: .natural, containsStart: false, containsEnd: true)


### PR DESCRIPTION
Fixes an issue where the width of the selection rect would sometimes be incorrect. This could happen in the case where the user selects the just the line break of a single line as shown below.

|Before|After|
|-|-|
|<img width="200" src="https://user-images.githubusercontent.com/830995/187357945-48bf77f5-3f85-4895-99dc-ee2ed4f93ad5.png"/>|<img width="200" src="https://user-images.githubusercontent.com/830995/187357915-0ea8e800-ed45-4bf9-83d8-4fd59a7ad116.png"/>|