### PR TITLE
Prevents selected range and marked range from being negative

### DIFF
--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -31,9 +31,13 @@ final class TextInputView: UIView, UITextInput {
             }
         }
         set {
-            // We should not use this setter. It's intended for UIKit to use.
-            // It'll invoke the setter in various scenarios, for example when navigating the text using the keyboard.
-            let newRange = (newValue as? IndexedRange)?.range
+            // We should not use this setter. It's intended for UIKit to use. It'll invoke the setter in various scenarios, for example when navigating the text using the keyboard.
+            // On the iOS 16 beta UIKit may be an NSRange like {4, -2} when double tapping to select text. This will ultimately cause crashes when UIKit later attempts to use the selected range with NSString's -substringWithRange:. This can be tested with a string containing the following three lines:
+            //    A
+            //
+            //    A
+            // Placing the character on the second line, which is empty, and double tapping several times on the empty line to select text will cause the editor to crash. To work around this we take the non-negative value of the selected range. Last tested on August 30th, 2022.
+            let newRange = (newValue as? IndexedRange)?.range.nonNegativeLength
             if newRange != _selectedRange {
                 // The logic for determining whether or not to notify the input delegate is based on advice provided by Alexander Blach, developer of Textastic.
                 var shouldNotifyInputDelegate = false
@@ -62,7 +66,7 @@ final class TextInputView: UIView, UITextInput {
             }
         }
         set {
-            markedRange = (newValue as? IndexedRange)?.range
+            markedRange = (newValue as? IndexedRange)?.range.nonNegativeLength
         }
     }
     var markedTextStyle: [NSAttributedString.Key: Any]?

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -32,7 +32,7 @@ final class TextInputView: UIView, UITextInput {
         }
         set {
             // We should not use this setter. It's intended for UIKit to use. It'll invoke the setter in various scenarios, for example when navigating the text using the keyboard.
-            // On the iOS 16 beta UIKit may be an NSRange like {4, -2} when double tapping to select text. This will ultimately cause crashes when UIKit later attempts to use the selected range with NSString's -substringWithRange:. This can be tested with a string containing the following three lines:
+            // On the iOS 16 beta, UIKit may pass an NSRange with a negatives length (e.g. {4, -2}) when double tapping to select text. This will cause a crash when UIKit later attempts to use the selected range with NSString's -substringWithRange:. This can be tested with a string containing the following three lines:
             //    A
             //
             //    A


### PR DESCRIPTION
On the iOS 16 beta, UIKit may pass an NSRange with a negatives length (e.g. {4, -2}) when double tapping to select text. This will cause a crash when UIKit later attempts to use the selected range with NSString's `-substringWithRange:`. This can be tested with a string containing the following three lines:

```
A

A
```

Placing the character on the second line, which is empty, and double tapping several times on the empty line to select text will cause the editor to crash. To work around this we take the non-negative value of the selected range.

This PR may fix the issue described in #147.