### PR TITLE
LineManager rebuilds tree from string in StringView

### DIFF
--- a/Sources/Runestone/LineManager/LineManager.swift
+++ b/Sources/Runestone/LineManager/LineManager.swift
@@ -48,6 +48,7 @@ final class LineManager {
         rootData.node = documentLineTree.root
     }
 
+    // swiftlint:disable:next function_body_length
     func rebuild() {
         // Reset the tree so we only have a single line.
         let rootData = DocumentLineNodeData(lineHeight: estimatedLineHeight)

--- a/Sources/Runestone/LineManager/LineManager.swift
+++ b/Sources/Runestone/LineManager/LineManager.swift
@@ -48,7 +48,7 @@ final class LineManager {
         rootData.node = documentLineTree.root
     }
 
-    func rebuild(from string: NSString) {
+    func rebuild() {
         // Reset the tree so we only have a single line.
         let rootData = DocumentLineNodeData(lineHeight: estimatedLineHeight)
         documentLineTree.reset(rootValue: 0, rootData: rootData)
@@ -56,14 +56,15 @@ final class LineManager {
         initialLongestLine = nil
         // Iterate over lines in the string.
         var line = documentLineTree.node(atIndex: 0)
-        var workingNewLineRange = NewLineFinder.rangeOfNextNewLine(in: string, startingAt: 0)
+        var workingNewLineRange = NewLineFinder.rangeOfNextNewLine(in: stringView.string, startingAt: 0)
         var lines: [DocumentLineNode] = []
         var lastDelimiterEnd = 0
         var totalLineHeight: CGFloat = 0
         var longestLineLength: Int = 0
         while let newLineRange = workingNewLineRange {
             let totalLength = newLineRange.location + newLineRange.length - lastDelimiterEnd
-            let substring = string.substring(with: NSRange(location: lastDelimiterEnd, length: totalLength))
+            let substringRange = NSRange(location: lastDelimiterEnd, length: totalLength)
+            let substring = stringView.string.substring(with: substringRange)
             line.value = totalLength
             line.data.totalLength = totalLength
             line.data.delimiterLength = newLineRange.length
@@ -79,11 +80,12 @@ final class LineManager {
             let data = DocumentLineNodeData(lineHeight: estimatedLineHeight)
             line = DocumentLineNode(tree: documentLineTree, value: 0, data: data)
             data.node = line
-            workingNewLineRange = NewLineFinder.rangeOfNextNewLine(in: string, startingAt: lastDelimiterEnd)
+            workingNewLineRange = NewLineFinder.rangeOfNextNewLine(in: stringView.string, startingAt: lastDelimiterEnd)
             totalLineHeight += estimatedLineHeight
         }
-        let totalLength = string.length - lastDelimiterEnd
-        let substring = string.substring(with: NSRange(location: lastDelimiterEnd, length: totalLength))
+        let totalLength = stringView.string.length - lastDelimiterEnd
+        let substringRange = NSRange(location: lastDelimiterEnd, length: totalLength)
+        let substring = stringView.string.substring(with: substringRange)
         line.value = totalLength
         line.data.totalLength = totalLength
         line.data.byteCount = substring.byteCount

--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -414,7 +414,7 @@ final class TextInputView: UIView, UITextInput {
             if newValue != stringView.string {
                 stringView.string = newValue
                 languageMode.parse(newValue)
-                lineManager.rebuild(from: newValue)
+                lineManager.rebuild()
                 if let oldSelectedRange = selectedRange {
                     inputDelegate?.selectionWillChange(self)
                     selectedRange = safeSelectionRange(from: oldSelectedRange)

--- a/Sources/Runestone/TextView/TextViewState.swift
+++ b/Sources/Runestone/TextView/TextViewState.swift
@@ -58,7 +58,7 @@ private extension TextViewState {
     private func prepare(with text: String) {
         let nsString = text as NSString
         lineManager.estimatedLineHeight = theme.font.totalLineHeight
-        lineManager.rebuild(from: nsString)
+        lineManager.rebuild()
         languageMode.parse(nsString)
         detectedIndentStrategy = languageMode.detectIndentStrategy()
         let lineEndingDetector = LineEndingDetector(lineManager: lineManager, stringView: stringView)

--- a/Tests/RunestoneTests/Helpers/LanguageModeFactory.swift
+++ b/Tests/RunestoneTests/Helpers/LanguageModeFactory.swift
@@ -75,7 +75,7 @@ enum LanguageModeFactory {
     static func languageMode(language: TreeSitterLanguage, text: String) -> TreeSitterInternalLanguageMode {
         let stringView = StringView(string: text)
         let lineManager = LineManager(stringView: stringView)
-        lineManager.rebuild(from: text as NSString)
+        lineManager.rebuild()
         let internalLanguage = language.internalLanguage
         return TreeSitterInternalLanguageMode(language: internalLanguage, languageProvider: nil, stringView: stringView, lineManager: lineManager)
     }

--- a/Tests/RunestoneTests/LineEndingDetectorTests.swift
+++ b/Tests/RunestoneTests/LineEndingDetectorTests.swift
@@ -87,7 +87,7 @@ private extension LineEndingDetectorTests {
     private func detectLineEndings(in string: String) -> LineEnding? {
         let stringView = StringView(string: string)
         let lineManager = LineManager(stringView: stringView)
-        lineManager.rebuild(from: string as NSString)
+        lineManager.rebuild()
         let detector = LineEndingDetector(lineManager: lineManager, stringView: stringView)
         return detector.detect()
     }


### PR DESCRIPTION
This PR removes the parameter provided to `rebuild(from:)` and always builds the tree of lines using the string in the StringView. This avoids the risk of passing a different string to the LineManager than what's inside the StringView.