### PR TITLE
Fixes issue where the -textInputViewDidChangeSelection(_:) was called too many times

### DIFF
--- a/Sources/Runestone/TextView/TextView.swift
+++ b/Sources/Runestone/TextView/TextView.swift
@@ -1097,7 +1097,6 @@ private extension TextView {
             textInputView.moveCaret(to: point)
             if textInputView.selectedRange != oldSelectedRange {
                 layoutIfNeeded()
-                editorDelegate?.textViewDidChangeSelection(self)
             }
             installEditableInteraction()
             becomeFirstResponder()


### PR DESCRIPTION
This PR fixes an issue where `-textInputViewDidChangeSelection(_:)` was called too many times in the following scenarios.

1. When tapping the TextView to start editing.
2. When deleting text the delegate would be called with the text to be deleted because `selectedTextRange` was set.

The first case was resolved by removing a call to the delegate in TextInputView.

The second case is a little more tricky and is resolved by removing the call to the delegate in `selectedTextRange` to give more control over when we're calling the delegate. We'll now call the delegate in `-layoutSubviews()` so we have a chance to abort the call in `deleteBackward()`.

The new behavior aligns better with the one of UITextView.

The changes fixes #158.