### PR TITLE
Implements isPosition(_:atLineBoundaryInDirection:)

### DIFF
--- a/Tests/RunestoneTests/TextInputStringTokenizerTests.swift
+++ b/Tests/RunestoneTests/TextInputStringTokenizerTests.swift
@@ -105,6 +105,46 @@ extension TextInputStringTokenizerTests {
         let indexedPosition = position as! IndexedPosition
         XCTAssertEqual(indexedPosition.index, 290)
     }
+
+    func testBeginningOfDocumentIsAtBoundary() {
+        let tokenizer = makeTokenizer()
+        let position = IndexedPosition(index: 0)
+        let textDirection = UITextDirection(rawValue: UITextStorageDirection.backward.rawValue)
+        let isAtBoundary = tokenizer.isPosition(position, atBoundary: .line, inDirection: textDirection)
+        XCTAssertTrue(isAtBoundary)
+    }
+
+    func testEndOfDocumentIsAtBoundary() {
+        let tokenizer = makeTokenizer()
+        let position = IndexedPosition(index: 457)
+        let textDirection = UITextDirection(rawValue: UITextStorageDirection.forward.rawValue)
+        let isAtBoundary = tokenizer.isPosition(position, atBoundary: .line, inDirection: textDirection)
+        XCTAssertTrue(isAtBoundary)
+    }
+
+    func testBeginningOfLineFragmentIsAtBoundary() {
+        let tokenizer = makeTokenizer()
+        let position = IndexedPosition(index: 35)
+        let textDirection = UITextDirection(rawValue: UITextStorageDirection.backward.rawValue)
+        let isAtBoundary = tokenizer.isPosition(position, atBoundary: .line, inDirection: textDirection)
+        XCTAssertFalse(isAtBoundary)
+    }
+
+    func testEndOfLineFragmentIsAtBoundary() {
+        let tokenizer = makeTokenizer()
+        let position = IndexedPosition(index: 87)
+        let textDirection = UITextDirection(rawValue: UITextStorageDirection.backward.rawValue)
+        let isAtBoundary = tokenizer.isPosition(position, atBoundary: .line, inDirection: textDirection)
+        XCTAssertFalse(isAtBoundary)
+    }
+
+    func testMiddleOfLineFragmentIsNotAtBoundary() {
+        let tokenizer = makeTokenizer()
+        let position = IndexedPosition(index: 35)
+        let textDirection = UITextDirection(rawValue: UITextStorageDirection.backward.rawValue)
+        let isAtBoundary = tokenizer.isPosition(position, atBoundary: .line, inDirection: textDirection)
+        XCTAssertFalse(isAtBoundary)
+    }
 }
 
 // MARK: - Movement in Paragraphs


### PR DESCRIPTION
This PR adds a meaningful implementation of `isPosition(_:atLineBoundaryInDirection:)`.

Adding this missing implementation fixes an issue where the caret was not placed correctly when tapping to move the caret around, especially not when selecting empty lines. This regression was introduced in #152.