### PR TITLE
node(containingLocation:) returns an optional

### DIFF
--- a/Sources/Runestone/LineManager/LineManager.swift
+++ b/Sources/Runestone/LineManager/LineManager.swift
@@ -103,7 +103,9 @@ final class LineManager {
         guard range.length > 0 else {
             return LineChangeSet()
         }
-        let startLine = documentLineTree.node(containingLocation: range.location)
+        guard let startLine = documentLineTree.node(containingLocation: range.location) else {
+            return LineChangeSet()
+        }
         if range.location > Int(startLine.location) + startLine.data.length {
             // Deleting starting in the middle of a delimiter.
             let changeSet = LineChangeSet()
@@ -120,7 +122,9 @@ final class LineManager {
             // possibly removing lines in between if multiple delimeters were deleted.
             let charactersRemovedInStartLine = Int(startLine.location) + startLine.value - range.location
             assert(charactersRemovedInStartLine > 0)
-            let endLine = documentLineTree.node(containingLocation: range.location + range.length)
+            guard let endLine = documentLineTree.node(containingLocation: range.location + range.length) else {
+                return LineChangeSet()
+            }
             if endLine === startLine {
                 // Removing characters in the last line.
                 return setLength(of: startLine, to: startLine.value - range.length)
@@ -147,7 +151,9 @@ final class LineManager {
     @discardableResult
     func insert(_ string: NSString, at location: Int) -> LineChangeSet {
         let changeSet = LineChangeSet()
-        var line = documentLineTree.node(containingLocation: location)
+        guard var line = documentLineTree.node(containingLocation: location) else {
+            return LineChangeSet()
+        }
         var lineLocation = Int(line.location)
         assert(location <= lineLocation + line.value)
         if location > lineLocation + line.data.length {

--- a/Sources/Runestone/RedBlackTree/RedBlackTree.swift
+++ b/Sources/Runestone/RedBlackTree/RedBlackTree.swift
@@ -34,10 +34,15 @@ final class RedBlackTree<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNode
         root.color = .black
     }
 
-    func node(containingLocation location: NodeValue) -> Node {
-        assert(location >= minimumValue)
-        assert(location <= root.nodeTotalValue)
-        return node(containingLocation: location, minimumValue: minimumValue, valueKeyPath: \.value, totalValueKeyPath: \.nodeTotalValue)!
+    func node(containingLocation location: NodeValue) -> Node? {
+        guard location >= minimumValue && location <= root.nodeTotalValue else {
+            #if DEBUG
+            fatalError("\(location) is out of bounds. Valid range is \(minimumValue) - \(root.nodeTotalValue). This issue is under investigation. Please open an issue at https://github.com/simonbs/Runestone/issues and include this stack trace and a sample text file if possible. This fatal error is only thrown in debug builds.")
+            #else
+            return nil
+            #endif
+        }
+        return node(containingLocation: location, minimumValue: minimumValue, valueKeyPath: \.value, totalValueKeyPath: \.nodeTotalValue)
     }
 
     func node<T: Comparable & AdditiveArithmetic>(containingLocation location: T,

--- a/Sources/Runestone/RedBlackTree/RedBlackTree.swift
+++ b/Sources/Runestone/RedBlackTree/RedBlackTree.swift
@@ -40,11 +40,10 @@ final class RedBlackTree<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNode
         return node(containingLocation: location, minimumValue: minimumValue, valueKeyPath: \.value, totalValueKeyPath: \.nodeTotalValue)!
     }
 
-    func node<T: Comparable & AdditiveArithmetic>(
-        containingLocation location: T,
-        minimumValue: T,
-        valueKeyPath: KeyPath<Node, T>,
-        totalValueKeyPath: KeyPath<Node, T>) -> Node? {
+    func node<T: Comparable & AdditiveArithmetic>(containingLocation location: T,
+                                                  minimumValue: T,
+                                                  valueKeyPath: KeyPath<Node, T>,
+                                                  totalValueKeyPath: KeyPath<Node, T>) -> Node? {
         if location == root[keyPath: totalValueKeyPath] {
             return root.rightMost
         } else {

--- a/Sources/Runestone/RedBlackTree/RedBlackTree.swift
+++ b/Sources/Runestone/RedBlackTree/RedBlackTree.swift
@@ -38,7 +38,7 @@ final class RedBlackTree<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNode
         guard location >= minimumValue && location <= root.nodeTotalValue else {
             #if DEBUG
             fatalError("\(location) is out of bounds. Valid range is \(minimumValue) - \(root.nodeTotalValue)."
-                       + " This issue is under investigation. Please open an issue at https://github.com/simonbs/Runestone/issues
+                       + " This issue is under investigation. Please open an issue at https://github.com/simonbs/Runestone/issues"
                        + " and include this stack trace and a sample text file if possible. This fatal error is only thrown in debug builds.")
             #else
             return nil

--- a/Sources/Runestone/RedBlackTree/RedBlackTree.swift
+++ b/Sources/Runestone/RedBlackTree/RedBlackTree.swift
@@ -37,7 +37,9 @@ final class RedBlackTree<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNode
     func node(containingLocation location: NodeValue) -> Node? {
         guard location >= minimumValue && location <= root.nodeTotalValue else {
             #if DEBUG
-            fatalError("\(location) is out of bounds. Valid range is \(minimumValue) - \(root.nodeTotalValue). This issue is under investigation. Please open an issue at https://github.com/simonbs/Runestone/issues and include this stack trace and a sample text file if possible. This fatal error is only thrown in debug builds.")
+            fatalError("\(location) is out of bounds. Valid range is \(minimumValue) - \(root.nodeTotalValue)."
+                       + " This issue is under investigation. Please open an issue at https://github.com/simonbs/Runestone/issues
+                       + " and include this stack trace and a sample text file if possible. This fatal error is only thrown in debug builds.")
             #else
             return nil
             #endif

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -164,7 +164,7 @@ final class LineController {
         return lineFragmentControllers(matching: query)
     }
 
-    func lineFragmentNode(containingCharacterAt location: Int) -> LineFragmentNode {
+    func lineFragmentNode(containingCharacterAt location: Int) -> LineFragmentNode? {
         return lineFragmentTree.node(containingLocation: location)
     }
 

--- a/Sources/Runestone/TextView/TextInput/LayoutManager.swift
+++ b/Sources/Runestone/TextView/TextInput/LayoutManager.swift
@@ -523,7 +523,9 @@ extension LayoutManager {
         guard lineController.numberOfLineFragments > 0 else {
             return false
         }
-        let lineFragmentNode = lineController.lineFragmentNode(containingCharacterAt: location)
+        guard let lineFragmentNode = lineController.lineFragmentNode(containingCharacterAt: location) else {
+            return false
+        }
         guard lineFragmentNode.index > 0 else {
             return false
         }

--- a/Sources/Runestone/TextView/TextInput/LineMovementController.swift
+++ b/Sources/Runestone/TextView/TextInput/LineMovementController.swift
@@ -61,7 +61,9 @@ private extension LineMovementController {
             return location
         }
         let lineLocalLocation = max(min(location - line.location, line.data.totalLength), 0)
-        let lineFragmentNode = lineController.lineFragmentNode(containingCharacterAt: lineLocalLocation)
+        guard let lineFragmentNode = lineController.lineFragmentNode(containingCharacterAt: lineLocalLocation) else {
+            return location
+        }
         let lineFragmentLocalLocation = lineLocalLocation - lineFragmentNode.location
         return locationForMoving(lineOffset: lineOffset, fromLocation: lineFragmentLocalLocation, inLineFragmentAt: lineFragmentNode.index, of: line)
     }

--- a/Sources/Runestone/TextView/TextInput/TextInputStringTokenizer.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputStringTokenizer.swift
@@ -67,7 +67,9 @@ private extension TextInputStringTokenizer {
         let lineLocation = line.location
         let lineLocalLocation = location - lineLocation
         let lineController = lineControllerStorage.getOrCreateLineController(for: line)
-        let lineFragmentNode = lineController.lineFragmentNode(containingCharacterAt: lineLocalLocation)
+        guard let lineFragmentNode = lineController.lineFragmentNode(containingCharacterAt: lineLocalLocation) else {
+            return false
+        }
         if direction.isForward {
             let isLastLineFragment = lineFragmentNode.index == lineController.numberOfLineFragments - 1
             if isLastLineFragment {
@@ -91,7 +93,9 @@ private extension TextInputStringTokenizer {
         let lineController = lineControllerStorage.getOrCreateLineController(for: line)
         let lineLocation = line.location
         let lineLocalLocation = location - lineLocation
-        let lineFragmentNode = lineController.lineFragmentNode(containingCharacterAt: lineLocalLocation)
+        guard let lineFragmentNode = lineController.lineFragmentNode(containingCharacterAt: lineLocalLocation) else {
+            return nil
+        }
         if direction.isForward {
             if location == stringView.string.length {
                 return position

--- a/Tests/RunestoneTests/LineManagerTests.swift
+++ b/Tests/RunestoneTests/LineManagerTests.swift
@@ -5,11 +5,11 @@ final class LineManagerTests: XCTestCase {
     func testLineLength() {
         let tree = DocumentLineTree(minimumValue: 0, rootValue: 0, rootData: .init(lineHeight: 0))
         let firstLine = tree.node(containingLocation: 0)
-        firstLine.data.totalLength = 6
-        firstLine.data.delimiterLength = 1
-        XCTAssertEqual(firstLine.data.length, 5)
-        firstLine.data.delimiterLength = 2
-        XCTAssertEqual(firstLine.data.length, 4)
+        firstLine?.data.totalLength = 6
+        firstLine?.data.delimiterLength = 1
+        XCTAssertEqual(firstLine?.data.length, 5)
+        firstLine?.data.delimiterLength = 2
+        XCTAssertEqual(firstLine?.data.length, 4)
     }
 
     func testLineDetails1() {


### PR DESCRIPTION
This PR attempts to fix #173.

The implementation of `node(containingLocation:)` has assumed that any callers will ensure that the value passed is valid, i.e. within the range of the string. However, that's a dangerous assumption, in particular as I suspect that UIKit may intentionally call functions on UITextInput with indices out of the string's range. That's an assumption that I've been unable to verify for now.

The safest thing is to make the function return an optional and keep an eye on any negative side effects.