### PR TITLE
Fixes issue where TextView could not be scrolled

### DIFF
--- a/Sources/Runestone/TextView/TextInput/TextInputView.swift
+++ b/Sources/Runestone/TextView/TextInput/TextInputView.swift
@@ -629,6 +629,7 @@ final class TextInputView: UIView, UITextInput {
             inputDelegate?.selectionDidChange(self)
         }
         if notifyDelegateAboutSelectionChangeInLayoutSubviews {
+            notifyDelegateAboutSelectionChangeInLayoutSubviews = false
             delegate?.textInputViewDidChangeSelection(self)
         }
     }


### PR DESCRIPTION
This PR fixes a regression introduced in #167 where the text view could not be called in the following scenario:

1. The user starts editing the text.
2. The user presses an arrow key to move the caret.
3. The user attempts to scroll the text view such that the caret moves out of the screen.

The above steps caused `-layoutSubviews()` to be called infinitely as long as the user was scrolling, making it appear that the content wasn't scrolled.