### PR TITLE
Updates caret location after moving lines

### DIFF
--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -1391,6 +1391,7 @@ extension TextInputView {
             replaceText(in: insertRange, with: text, undoActionName: undoActionName)
             // Update the selected range to match the old one but at the new lines.
             let locationOffset = insertLocation - removeLocation
+            notifyInputDelegateAboutSelectionChangeInLayoutSubviews = true
             selectedRange = NSRange(location: oldSelectedRange.location + locationOffset, length: oldSelectedRange.length)
             timedUndoManager.endUndoGrouping()
         }


### PR DESCRIPTION
Fixes issue where the input delegate was not notified of the updated selection range when moving lines up and down.