### PR TITLE
Fixes default value of isLineWrappingEnabled

### DIFF
--- a/Sources/Runestone/TextView/Core/ContentSizeService.swift
+++ b/Sources/Runestone/TextView/Core/ContentSizeService.swift
@@ -11,7 +11,7 @@ final class ContentSizeService {
             }
         }
     }
-    var isLineWrappingEnabled = false {
+    var isLineWrappingEnabled = true {
         didSet {
             if isLineWrappingEnabled != oldValue {
                 invalidateContentSize()


### PR DESCRIPTION
The incorrect default value caused the ContentSizeService to return an incorrect content size when line wrapping was disabled.