### PR TITLE
Makes scrollRangeToVisible(_:animated:) public

### DIFF
--- a/Sources/Runestone/TextView/SearchAndReplace/UITextSearchingHelper.swift
+++ b/Sources/Runestone/TextView/SearchAndReplace/UITextSearchingHelper.swift
@@ -131,7 +131,7 @@ extension UITextSearchingHelper: UITextSearching {
 
     func scrollRangeToVisible(_ range: UITextRange, inDocument: AnyHashable??) {
         if let indexedRange = range as? IndexedRange {
-            _textView.scroll(to: indexedRange.range)
+            _textView.scrollRangeToVisible(indexedRange.range)
         }
     }
 }


### PR DESCRIPTION
This PR replaces the `-scroll(to:)` function with `scrollRangeToVisible(_:animated:)` and makes it public.

The implementation of has also been drastically changed so it no longer needs `contentOffset(forScrollingToLocation:)`. This change was made because I remembered that UIScrollView has `scrollRectToVisible(_:animated:)` which it seems that we can piggyback on.

The benefit of `-scrollRangeToVisible(_:animated:)` is that it ensures that the text has been typeset to the specified range, and as such, that we can scroll to it. However, the resulting offset may be slightly off due to asynchronous syntax highlighting.

The PR addresses #177 