### PR TITLE
Improves logic for scrolling to a specified range

### DIFF
--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -1093,6 +1093,7 @@ extension TextView {
     ///   - range: The range of text to scroll into view.
     ///   - animated: Whether the scroll should be performed animated. Defaults to false.
     public func scrollRangeToVisible(_ range: NSRange, animated: Bool = false) {
+        textInputView.layoutLines(toLocation: range.upperBound)
         let lowerBoundRect = textInputView.caretRect(at: range.lowerBound)
         let upperBoundRect = range.length == 0 ? lowerBoundRect : textInputView.caretRect(at: range.upperBound)
         let minX = min(lowerBoundRect.minX, upperBoundRect.minX)


### PR DESCRIPTION
PR #197 changed the logic for scrolling a specified range to use UIScrollView's `scrollRectToVisible(_:animated:)`. However, that did not work properly as it didn't take the gutter width into account.

This PR rewrites the logic to be closer to the logic used prior to #197 but at the same time improves the logic to reveal more of the specified range.

This PR also fixes a bug where `scrollRangeToVisible(_:animated:)` would not always scroll to the correct position in the text because the text had not been laid out.