### PR TITLE
💥 Removes the automaticScrollInset property

### DIFF
--- a/Example/Example/Main/MainViewController.swift
+++ b/Example/Example/Main/MainViewController.swift
@@ -196,10 +196,8 @@ private extension MainViewController {
     }
 
     private func updateInsets(keyboardHeight: CGFloat) {
-        let textView = contentView.textView
-        textView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardHeight, right: 0)
-        textView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardHeight, right: 0)
-        textView.automaticScrollInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardHeight, right: 0)
+        contentView.textView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardHeight, right: 0)
+        contentView.textView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardHeight, right: 0)
     }
 }
 

--- a/Sources/Runestone/Documentation.docc/Extensions/TextView.md
+++ b/Sources/Runestone/Documentation.docc/Extensions/TextView.md
@@ -160,7 +160,6 @@
 
 - ``contentOffset``
 - ``isAutomaticScrollEnabled``
-- ``automaticScrollInset``
 
 ### Laying Out Subviews
 

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -491,10 +491,6 @@ open class TextView: UIScrollView {
     }
     /// Automatically scrolls the text view to show the caret when typing or moving the caret.
     public var isAutomaticScrollEnabled = true
-    /// When automatic scrolling is enabled and the caret leaves the viewport, the text view will automatically scroll the content.
-    ///
-    /// The `automaticScrollInset` is applied to the viewport before scrolling. The inset can be used to adjust when the text view should scroll the content. For example it can be used to account for views overlaying the content. The text view will does account for the keyboard or the status bar.
-    public var automaticScrollInset: UIEdgeInsets = .zero
     /// Amount of overscroll to add in the vertical direction.
     ///
     /// The overscroll is a factor of the scrollable area height and will not take into account any insets. 0 means no overscroll and 1 means an amount equal to the height of the text view. Detaults to 0.


### PR DESCRIPTION
This PR removes the `automaticScrollInset` property on TextView. The property was introduced to let developers fine tune the behavior when scrolling in the TextView. However, the purpose of the property was difficult to understand, maintaining it was complicated, and its usage seemed low. Therefore I've decided to remove it.

If this causes problems for any developer then I'd be more than happy to discuss how we can resolve these, potentially with a better API.