### PR TITLE
Only enables easy selection of delimiter when selecting text

### DIFF
--- a/Sources/Runestone/TextView/Core/LayoutManager.swift
+++ b/Sources/Runestone/TextView/Core/LayoutManager.swift
@@ -256,25 +256,26 @@ extension LayoutManager {
         let adjustedYPosition = point.y - textContainerInset.top
         let adjustedPoint = CGPoint(x: adjustedXPosition, y: adjustedYPosition)
         if let line = lineManager.line(containingYOffset: adjustedPoint.y), let lineController = lineControllerStorage[line.id] {
-            return closestIndex(to: adjustedPoint, in: lineController, showing: line)
+            return closestIndex(to: adjustedPoint, in: lineController)
         } else if adjustedPoint.y <= 0 {
             let firstLine = lineManager.firstLine
-            if let textRenderer = lineControllerStorage[firstLine.id] {
-                return closestIndex(to: adjustedPoint, in: textRenderer, showing: firstLine)
+            if let lineController = lineControllerStorage[firstLine.id] {
+                return closestIndex(to: adjustedPoint, in: lineController)
             } else {
                 return 0
             }
         } else {
             let lastLine = lineManager.lastLine
-            if adjustedPoint.y >= lastLine.yPosition, let textRenderer = lineControllerStorage[lastLine.id] {
-                return closestIndex(to: adjustedPoint, in: textRenderer, showing: lastLine)
+            if adjustedPoint.y >= lastLine.yPosition, let lineController = lineControllerStorage[lastLine.id] {
+                return closestIndex(to: adjustedPoint, in: lineController)
             } else {
                 return stringView.string.length
             }
         }
     }
 
-    private func closestIndex(to point: CGPoint, in lineController: LineController, showing line: DocumentLineNode) -> Int {
+    private func closestIndex(to point: CGPoint, in lineController: LineController) -> Int {
+        let line = lineController.line
         let localPoint = CGPoint(x: point.x, y: point.y - line.yPosition)
         return lineController.closestIndex(to: localPoint)
     }

--- a/Sources/Runestone/TextView/Core/LayoutManager.swift
+++ b/Sources/Runestone/TextView/Core/LayoutManager.swift
@@ -277,7 +277,8 @@ extension LayoutManager {
     private func closestIndex(to point: CGPoint, in lineController: LineController) -> Int {
         let line = lineController.line
         let localPoint = CGPoint(x: point.x, y: point.y - line.yPosition)
-        return lineController.closestIndex(to: localPoint)
+        let allowEasySelectionOfDelimiter = (selectedRange?.length ?? 0) > 0
+        return lineController.closestIndex(to: localPoint, allowEasySelectionOfDelimiter: allowEasySelectionOfDelimiter)
     }
 }
 

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -454,12 +454,12 @@ extension LineController {
         return CGRect(x: 0, y: 0, width: 0, height: estimatedLineFragmentHeight * lineFragmentHeightMultiplier)
     }
 
-    func closestIndex(to point: CGPoint) -> Int {
+    func closestIndex(to point: CGPoint, allowEasySelectionOfDelimiter: Bool) -> Int {
         guard let closestLineFragment = lineFragment(closestTo: point) else {
             return 0
         }
         let localLocation = min(CTLineGetStringIndexForPosition(closestLineFragment.line, point), line.data.length)
-        if closestLineFragment === typesetter.lineFragments.last {
+        if allowEasySelectionOfDelimiter && closestLineFragment === typesetter.lineFragments.last {
             let lastCharacterRect = caretRect(atIndex: closestLineFragment.range.upperBound)
             if point.x >= lastCharacterRect.maxX + 50 {
                 // Location is significantly far from the last character and therefore we select the entire line, including the delimiter.


### PR DESCRIPTION
This PR fixes an issue where tapping at the end of the line would move the caret to the following line because it would select the line delimiter.

However, we still partly want this logic as we want to make it easy to select the line delimiter when selecting a range of text. Therefore we introduce the `allowEasySelectionOfDelimiter` parameter which is true when `selectedRange.length > 0`.