### PR TITLE
Only typeset lines when absolutely needed

### DIFF
--- a/Sources/Runestone/TextView/Core/LayoutManager.swift
+++ b/Sources/Runestone/TextView/Core/LayoutManager.swift
@@ -377,7 +377,7 @@ extension LayoutManager {
             let lineSize = CGSize(width: lineController.lineWidth, height: lineController.lineHeight)
             contentSizeService.setSize(of: lineController.line, to: lineSize)
             let lineEndLocation = lineLocation + line.data.length
-            if (lineEndLocation < location) || (lineLocation == location && !isLocationEndOfString) {
+            if ((lineEndLocation < location) || (lineLocation == location && !isLocationEndOfString)) && line.index < lineManager.lineCount - 1 {
                 nextLine = lineManager.line(atRow: line.index + 1)
             } else {
                 nextLine = nil

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -1108,14 +1108,7 @@ extension TextView {
     ///   - range: The range of text to scroll into view.
     public func scrollRangeToVisible(_ range: NSRange) {
         textInputView.layoutLines(toLocation: range.upperBound)
-        let lowerBoundRect = textInputView.caretRect(at: range.lowerBound)
-        let upperBoundRect = range.length == 0 ? lowerBoundRect : textInputView.caretRect(at: range.upperBound)
-        let rectMinX = min(lowerBoundRect.minX, upperBoundRect.minX)
-        let rectMaxX = max(lowerBoundRect.maxX, upperBoundRect.maxX)
-        let rectMinY = min(lowerBoundRect.minY, upperBoundRect.minY)
-        let rectMaxY = max(lowerBoundRect.maxY, upperBoundRect.maxY)
-        let rect = CGRect(x: rectMinX, y: rectMinY, width: rectMaxX - rectMinX, height: rectMaxY - rectMinY)
-        contentOffset = contentOffsetForScrollingToVisibleRect(rect)
+        justScrollRangeToVisible(range)
     }
 }
 
@@ -1220,9 +1213,20 @@ private extension TextView {
         }
     }
 
+    private func justScrollRangeToVisible(_ range: NSRange) {
+        let lowerBoundRect = textInputView.caretRect(at: range.lowerBound)
+        let upperBoundRect = range.length == 0 ? lowerBoundRect : textInputView.caretRect(at: range.upperBound)
+        let rectMinX = min(lowerBoundRect.minX, upperBoundRect.minX)
+        let rectMaxX = max(lowerBoundRect.maxX, upperBoundRect.maxX)
+        let rectMinY = min(lowerBoundRect.minY, upperBoundRect.minY)
+        let rectMaxY = max(lowerBoundRect.maxY, upperBoundRect.maxY)
+        let rect = CGRect(x: rectMinX, y: rectMinY, width: rectMaxX - rectMinX, height: rectMaxY - rectMinY)
+        contentOffset = contentOffsetForScrollingToVisibleRect(rect)
+    }
+
     private func scrollLocationToVisible(_ location: Int) {
         let range = NSRange(location: location, length: 0)
-        scrollRangeToVisible(range)
+        justScrollRangeToVisible(range)
     }
 
     private func installEditableInteraction() {
@@ -1396,8 +1400,6 @@ extension TextView: HighlightNavigationControllerDelegate {
     func highlightNavigationController(_ controller: HighlightNavigationController,
                                        shouldNavigateTo highlightNavigationRange: HighlightNavigationRange) {
         let range = highlightNavigationRange.range
-        // Layout lines up until the location of the range so we can scroll to it immediately after.
-        textInputView.layoutLines(toLocation: range.upperBound)
         scrollRangeToVisible(range)
         textInputView.selectedTextRange = IndexedRange(range)
         _ = textInputView.becomeFirstResponder()

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -889,6 +889,14 @@ open class TextView: UIScrollView {
     }
 
     /// Search for the specified query.
+    ///
+    /// The code below shows how a ``SearchQuery`` can be constructed and passed to ``search(for:)``.
+    ///
+    /// ```swift
+    /// let query = SearchQuery(text: "foo", matchMethod: .contains, isCaseSensitive: false)
+    /// let results = textView.search(for: query)
+    /// ```
+    ///
     /// - Parameter query: Query to find matches for.
     /// - Returns: Results matching the query.
     public func search(for query: SearchQuery) -> [SearchResult] {
@@ -901,7 +909,7 @@ open class TextView: UIScrollView {
     ///
     /// When searching for a regular expression this function will perform pattern matching and take the matched groups into account in the returned results.
     ///
-    /// The code below exemplifies how the returned search results can be used to perform a replace operation.
+    /// The code below shows how a ``SearchQuery`` can be constructed and passed to ``search(for:replacingMatchesWith:)`` and how the returned search results can be used to perform a replace operation.
     ///
     /// ```swift
     /// let query = SearchQuery(text: "foo", matchMethod: .contains, isCaseSensitive: false)


### PR DESCRIPTION
Starting from #198  `scrollRangeToVisible(_:)` will layout lines and all functions in TextInputView will call `scrollRangeToVisible(_:)` when needing to scroll the text view, either directly or indirectly. However, this causes layout passes that wasn't needed prior to #198. This PR maintains the old behavior where we did not always layout lines when scrolling the text view.