### PR TITLE
Removes easy selection of line ending

### DIFF
--- a/Sources/Runestone/TextView/Core/LayoutManager.swift
+++ b/Sources/Runestone/TextView/Core/LayoutManager.swift
@@ -277,8 +277,7 @@ extension LayoutManager {
     private func closestIndex(to point: CGPoint, in lineController: LineController) -> Int {
         let line = lineController.line
         let localPoint = CGPoint(x: point.x, y: point.y - line.yPosition)
-        let allowEasySelectionOfDelimiter = (selectedRange?.length ?? 0) > 0
-        return lineController.closestIndex(to: localPoint, allowEasySelectionOfDelimiter: allowEasySelectionOfDelimiter)
+        return lineController.closestIndex(to: localPoint)
     }
 }
 

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -454,22 +454,12 @@ extension LineController {
         return CGRect(x: 0, y: 0, width: 0, height: estimatedLineFragmentHeight * lineFragmentHeightMultiplier)
     }
 
-    func closestIndex(to point: CGPoint, allowEasySelectionOfDelimiter: Bool) -> Int {
+    func closestIndex(to point: CGPoint) -> Int {
         guard let closestLineFragment = lineFragment(closestTo: point) else {
             return 0
         }
         let localLocation = min(CTLineGetStringIndexForPosition(closestLineFragment.line, point), line.data.length)
-        if allowEasySelectionOfDelimiter && closestLineFragment === typesetter.lineFragments.last {
-            let lastCharacterRect = caretRect(atIndex: closestLineFragment.range.upperBound)
-            if point.x >= lastCharacterRect.maxX + 50 {
-                // Location is significantly far from the last character and therefore we select the entire line, including the delimiter.
-                return line.location + line.data.length + line.data.delimiterLength
-            } else {
-                return line.location + localLocation
-            }
-        } else {
-            return line.location + localLocation
-        }
+        return line.location + localLocation
     }
 }
 


### PR DESCRIPTION
The logic for easily selecting line endings mostly worked fine but caused unexpected selection results that differ too much from standard UITextView. Therefore we remove it.