### PR TITLE
Fixes highlighted range not rendered

### DIFF
--- a/Sources/Runestone/TextView/Core/LayoutManager.swift
+++ b/Sources/Runestone/TextView/Core/LayoutManager.swift
@@ -413,6 +413,7 @@ extension LayoutManager {
                 let lineFragment = lineFragmentController.lineFragment
                 var lineFragmentFrame: CGRect = .zero
                 appearedLineFragmentIDs.insert(lineFragment.id)
+                lineFragmentController.highlightedRangeFragments = highlightService.highlightedRangeFragments(for: lineFragment, inLineWithID: line.id)
                 layoutLineFragmentView(for: lineFragmentController, lineYPosition: lineYPosition, lineFragmentFrame: &lineFragmentFrame)
                 maxY = lineFragmentFrame.maxY
             }

--- a/Sources/Runestone/TextView/Core/LayoutManager.swift
+++ b/Sources/Runestone/TextView/Core/LayoutManager.swift
@@ -413,7 +413,8 @@ extension LayoutManager {
                 let lineFragment = lineFragmentController.lineFragment
                 var lineFragmentFrame: CGRect = .zero
                 appearedLineFragmentIDs.insert(lineFragment.id)
-                lineFragmentController.highlightedRangeFragments = highlightService.highlightedRangeFragments(for: lineFragment, inLineWithID: line.id)
+                lineFragmentController.highlightedRangeFragments = highlightService.highlightedRangeFragments(for: lineFragment,
+                                                                                                              inLineWithID: line.id)
                 layoutLineFragmentView(for: lineFragmentController, lineYPosition: lineYPosition, lineFragmentFrame: &lineFragmentFrame)
                 maxY = lineFragmentFrame.maxY
             }

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -192,7 +192,6 @@ private extension LineController {
     private func prepareToDisplayString(_ typesetAmount: TypesetAmount, syntaxHighlightAsynchronously: Bool) {
         prepareString(syntaxHighlightAsynchronously: syntaxHighlightAsynchronously)
         typesetLineFragments(typesetAmount)
-        updateHighlightedRangeFragments()
     }
 
     private func prepareString(syntaxHighlightAsynchronously: Bool) {
@@ -400,14 +399,6 @@ private extension LineController {
     private func applyTheme(to lineFragmentController: LineFragmentController) {
         lineFragmentController.markedTextBackgroundColor = theme.markedTextBackgroundColor
         lineFragmentController.markedTextBackgroundCornerRadius = theme.markedTextBackgroundCornerRadius
-    }
-
-    private func updateHighlightedRangeFragments() {
-        for (_, lineFragmentController) in lineFragmentControllers {
-            let lineFragment = lineFragmentController.lineFragment
-            let highlightedRangeFragments = highlightService.highlightedRangeFragments(for: lineFragment, inLineWithID: line.id)
-            lineFragmentController.highlightedRangeFragments = highlightedRangeFragments
-        }
     }
 
     private func lineFragment(closestTo point: CGPoint) -> LineFragment? {


### PR DESCRIPTION
This PR fixes an issue where the background of a highlighted range would not be drawn (i.e. the text would not appear to be highlighted) after performing the following sequence of events:

1. Search for a query using iOS 16's standard UIFindInteraction. This can be done in the example app.
2. Navigate to a match that is outside of the screen.
3. Observe that the text view has scrolled to the match but it isn't highlighted.

The reason is that LineController would attempt to pass highlighted ranges to its LineFragmentControllers prior to them being created, that is, the `lineFragmentControllers` array was empty.

The fix is to ask the LayoutManager to pass the highlighted ranges to the LineFragmentController at the point of drawing line fragment. This has the additional benefit of the highlighted ranges being created for a line fragment lazily.