### PR TITLE
closestIndex(to:) returns beginning of line if line fragment is unavailable

### DIFF
--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -447,7 +447,7 @@ extension LineController {
 
     func closestIndex(to point: CGPoint) -> Int {
         guard let closestLineFragment = lineFragment(closestTo: point) else {
-            return 0
+            return line.location
         }
         let localLocation = min(CTLineGetStringIndexForPosition(closestLineFragment.line, point), line.data.length)
         return line.location + localLocation


### PR DESCRIPTION
This PR fixes an issue where the caret would be placed at the beginning of the document when attempting to select the last line in the editor.

The error occurred because `closestIndex(to:)` on LineController returned location 0 which is the beginning of the document. Instead it should return `line.location` which is the beginning of the line.

Fixes #217.