### PR TITLE
Clears LineControllerStorage when setting TextViewState

### DIFF
--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -767,6 +767,7 @@ final class TextInputView: UIView, UITextInput {
         stringView = state.stringView
         theme = state.theme
         languageMode = state.languageMode
+        lineControllerStorage.removeAllLineControllers()
         lineManager = state.lineManager
         lineManager.estimatedLineHeight = estimatedLineHeight
         layoutManager.languageMode = state.languageMode

--- a/Sources/Runestone/TextView/LineController/LineControllerStorage.swift
+++ b/Sources/Runestone/TextView/LineController/LineControllerStorage.swift
@@ -43,6 +43,10 @@ final class LineControllerStorage {
         lineControllers.removeValue(forKey: lineID)
     }
 
+    func removeAllLineControllers() {
+        lineControllers.removeAll()
+    }
+
     func removeAllLineControllers(exceptLinesWithID exceptionLineIDs: Set<DocumentLineNodeID>) {
         let allLineIDs = Set(lineControllers.keys)
         let lineIDsToRelease = allLineIDs.subtracting(exceptionLineIDs)


### PR DESCRIPTION
The LineControllerStorage was not cleared when the TextViewState, and as such the LineManager, was updated. That meant we had that the storage would contain line controllers that were no longer in use as the lines had gotten a new ID.

This PR is part of the fix for #226.