### PR TITLE
Disables processing character pairs when combining Korean letters

### DIFF
--- a/Example/ExampleUITests/KoreanInputTests.swift
+++ b/Example/ExampleUITests/KoreanInputTests.swift
@@ -82,6 +82,18 @@ final class KoreanInputTests: XCTestCase {
         app.keys["ㄹ"].tap()
         XCTAssertEqual(app.textView?.value as? String, "강물")
     }
+
+    func testEnteringKoreanBetweenQuotationMarks() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.clearTextView()
+        app.keys["more"].tap()
+        app.keys["\""].tap()
+        app.keys["more"].tap()
+        app.keys["ㅇ"].tap()
+        app.keys["ㅓ"].tap()
+        XCTAssertEqual(app.textView?.value as? String, "\"어\"")
+    }
 }
 
 private extension XCUIApplication {

--- a/Sources/Runestone/TextView/Core/TextInputStringTokenizer.swift
+++ b/Sources/Runestone/TextView/Core/TextInputStringTokenizer.swift
@@ -1,8 +1,9 @@
 import UIKit
 
 final class TextInputStringTokenizer: UITextInputStringTokenizer {
-    private let stringView: StringView
-    private let lineManager: LineManager
+    var lineManager: LineManager
+    var stringView: StringView
+
     private let lineControllerStorage: LineControllerStorage
     private var newlineCharacters: [Character] {
         return [Symbol.Character.lineFeed, Symbol.Character.carriageReturn, Symbol.Character.carriageReturnLineFeed]

--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -536,7 +536,7 @@ final class TextInputView: UIView, UITextInput {
         return textSelectionView?.subviews.count == 1
     }
     var lineEndings: LineEnding = .lf
-    private(set) var isRestoringPreviosulyDeletedText = false
+    private(set) var isRestoringPreviouslyDeletedText = false
 
     // MARK: - Private
     private var languageMode: InternalLanguageMode = PlainTextInternalLanguageMode() {
@@ -1083,15 +1083,15 @@ extension TextInputView {
 extension TextInputView {
     func insertText(_ text: String) {
         let preparedText = prepareTextForInsertion(text)
-        isRestoringPreviosulyDeletedText = hasDeletedTextWithPendingLayoutSubviews
+        isRestoringPreviouslyDeletedText = hasDeletedTextWithPendingLayoutSubviews
         hasDeletedTextWithPendingLayoutSubviews = false
         defer {
-            isRestoringPreviosulyDeletedText = false
+            isRestoringPreviouslyDeletedText = false
         }
         // If there is no marked range or selected range then we fallback to appending text to the end of our string.
         let selectedRange = markedRange ?? selectedRange ?? NSRange(location: stringView.string.length, length: 0)
         guard shouldChangeText(in: selectedRange, replacementText: preparedText) else {
-            isRestoringPreviosulyDeletedText = false
+            isRestoringPreviouslyDeletedText = false
             return
         }
         // If we're inserting text then we can't have a marked range. However, UITextInput doesn't always clear the marked range

--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -81,10 +81,13 @@ final class TextInputView: UIView, UITextInput {
     var hasText: Bool {
         return string.length > 0
     }
-    private(set) lazy var tokenizer: UITextInputTokenizer = TextInputStringTokenizer(textInput: self,
-                                                                                     stringView: stringView,
-                                                                                     lineManager: lineManager,
-                                                                                     lineControllerStorage: lineControllerStorage)
+    var tokenizer: UITextInputTokenizer {
+        return customTokenizer
+    }
+    private lazy var customTokenizer = TextInputStringTokenizer(textInput: self,
+                                                                stringView: stringView,
+                                                                lineManager: lineManager,
+                                                                lineControllerStorage: lineControllerStorage)
     var autocorrectionType: UITextAutocorrectionType = .default
     var autocapitalizationType: UITextAutocapitalizationType = .sentences
     var smartQuotesType: UITextSmartQuotesType = .default
@@ -511,6 +514,7 @@ final class TextInputView: UIView, UITextInput {
                 layoutManager.stringView = stringView
                 indentController.stringView = stringView
                 lineMovementController.stringView = stringView
+                customTokenizer.stringView = stringView
             }
         }
     }
@@ -524,6 +528,7 @@ final class TextInputView: UIView, UITextInput {
                 caretRectService.lineManager = lineManager
                 selectionRectService.lineManager = lineManager
                 highlightService.lineManager = lineManager
+                customTokenizer.lineManager = lineManager
             }
         }
     }

--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -536,7 +536,7 @@ final class TextInputView: UIView, UITextInput {
         return textSelectionView?.subviews.count == 1
     }
     var lineEndings: LineEnding = .lf
-    private(set) var isInsertingTextToCombineCharacters = false
+    private(set) var isRestoringPreviosulyDeletedText = false
 
     // MARK: - Private
     private var languageMode: InternalLanguageMode = PlainTextInternalLanguageMode() {
@@ -1083,15 +1083,15 @@ extension TextInputView {
 extension TextInputView {
     func insertText(_ text: String) {
         let preparedText = prepareTextForInsertion(text)
-        isInsertingTextToCombineCharacters = hasDeletedTextWithPendingLayoutSubviews
+        isRestoringPreviosulyDeletedText = hasDeletedTextWithPendingLayoutSubviews
         hasDeletedTextWithPendingLayoutSubviews = false
         defer {
-            isInsertingTextToCombineCharacters = false
+            isRestoringPreviosulyDeletedText = false
         }
         // If there is no marked range or selected range then we fallback to appending text to the end of our string.
         let selectedRange = markedRange ?? selectedRange ?? NSRange(location: stringView.string.length, length: 0)
         guard shouldChangeText(in: selectedRange, replacementText: preparedText) else {
-            isInsertingTextToCombineCharacters = false
+            isRestoringPreviosulyDeletedText = false
             return
         }
         // If we're inserting text then we can't have a marked range. However, UITextInput doesn't always clear the marked range

--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -536,6 +536,7 @@ final class TextInputView: UIView, UITextInput {
         return textSelectionView?.subviews.count == 1
     }
     var lineEndings: LineEnding = .lf
+    private(set) var isInsertingTextToCombineCharacters = false
 
     // MARK: - Private
     private var languageMode: InternalLanguageMode = PlainTextInternalLanguageMode() {
@@ -587,6 +588,7 @@ final class TextInputView: UIView, UITextInput {
     private var notifyInputDelegateAboutSelectionChangeInLayoutSubviews = false
     private var notifyDelegateAboutSelectionChangeInLayoutSubviews = false
     private var didCallPositionFromPositionInDirectionWithOffset = false
+    private var hasDeletedTextWithPendingLayoutSubviews = false
     private var preserveUndoStackWhenSettingString = false
     private var cancellables: [AnyCancellable] = []
 
@@ -677,6 +679,7 @@ final class TextInputView: UIView, UITextInput {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        hasDeletedTextWithPendingLayoutSubviews = false
         layoutManager.layoutIfNeeded()
         layoutManager.layoutLineSelectionIfNeeded()
         layoutPageGuideIfNeeded()
@@ -1080,9 +1083,15 @@ extension TextInputView {
 extension TextInputView {
     func insertText(_ text: String) {
         let preparedText = prepareTextForInsertion(text)
+        isInsertingTextToCombineCharacters = hasDeletedTextWithPendingLayoutSubviews
+        hasDeletedTextWithPendingLayoutSubviews = false
+        defer {
+            isInsertingTextToCombineCharacters = false
+        }
         // If there is no marked range or selected range then we fallback to appending text to the end of our string.
         let selectedRange = markedRange ?? selectedRange ?? NSRange(location: stringView.string.length, length: 0)
         guard shouldChangeText(in: selectedRange, replacementText: preparedText) else {
+            isInsertingTextToCombineCharacters = false
             return
         }
         // If we're inserting text then we can't have a marked range. However, UITextInput doesn't always clear the marked range
@@ -1092,7 +1101,6 @@ extension TextInputView {
         markedRange = nil
         if LineEnding(symbol: text) != nil {
             indentController.insertLineBreak(in: selectedRange, using: lineEndings)
-            layoutIfNeeded()
             delegate?.textInputViewDidChangeSelection(self)
         } else {
             replaceText(in: selectedRange, with: preparedText)
@@ -1113,6 +1121,13 @@ extension TextInputView {
         guard shouldChangeText(in: deleteRange, replacementText: "") else {
             return
         }
+        // Set a flag indicating that we have deleted text. This is reset in -layoutSubviews() but if this has not been reset before insertText() is called, then UIKit deleted characters prior to inserting combined characters. This happens when UIKit turns Korean characters into a single character. E.g. when typing ㅇ followed by ㅓ UIKit will perform the following operations:
+        // 1. Delete ㅇ.
+        // 2. Delete the character before ㅇ. I'm unsure why this is needed.
+        // 3. Insert the character that was previously before ㅇ.
+        // 4. Insert the ㅇ and ㅓ but combined into the single character delete ㅇ and then insert 어.
+        // We can detect this case in insertText() by checking if this variable is true.
+        hasDeletedTextWithPendingLayoutSubviews = true
         // Disable notifying delegate in layout subviews to prevent sending the selected range with length > 0 when deleting text. This aligns with the behavior of UITextView and was introduced to resolve issue #158: https://github.com/simonbs/Runestone/issues/158
         notifyDelegateAboutSelectionChangeInLayoutSubviews = false
         // Disable notifying input delegate in layout subviews to prevent issues when entering Korean text. This workaround is inspired by a dialog with Alexander Black (@lextar), developer of Textastic.
@@ -1239,7 +1254,6 @@ extension TextInputView {
         lineChangeSet.union(with: languageModeLineChangeSet)
         applyLineChangesToLayoutManager(lineChangeSet)
         let updatedTextEditResult = TextEditResult(textChange: textChange, lineChangeSet: lineChangeSet)
-        layoutIfNeeded()
         delegate?.textInputViewDidChange(self)
         if updatedTextEditResult.didAddOrRemoveLines {
             delegate?.textInputViewDidInvalidateContentSize(self)

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -1356,7 +1356,8 @@ extension TextView: TextInputViewDelegate {
         if textInputView.isRestoringPreviouslyDeletedText {
             // UIKit is inserting text to combine characters, for example to combine two Korean characters into one, and we do not want to interfere with that.
             return editorDelegate?.textView(self, shouldChangeTextIn: range, replacementText: text) ?? true
-        } else if let characterPair = characterPairs.first(where: { $0.trailing == text }), skipInsertingTrailingComponent(of: characterPair, in: range) {
+        } else if let characterPair = characterPairs.first(where: { $0.trailing == text }),
+                    skipInsertingTrailingComponent(of: characterPair, in: range) {
             return false
         } else if let characterPair = characterPairs.first(where: { $0.leading == text }), insertLeadingComponent(of: characterPair, in: range) {
             return false

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -1353,7 +1353,10 @@ extension TextView: TextInputViewDelegate {
     }
 
     func textInputView(_ view: TextInputView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        if let characterPair = characterPairs.first(where: { $0.trailing == text }), skipInsertingTrailingComponent(of: characterPair, in: range) {
+        if textInputView.isInsertingTextToCombineCharacters {
+            // UIKit is inserting text to combine characters, for example to combine two Korean characters into one, and we do not want to interfere with that.
+            return editorDelegate?.textView(self, shouldChangeTextIn: range, replacementText: text) ?? true
+        } else if let characterPair = characterPairs.first(where: { $0.trailing == text }), skipInsertingTrailingComponent(of: characterPair, in: range) {
             return false
         } else if let characterPair = characterPairs.first(where: { $0.leading == text }), insertLeadingComponent(of: characterPair, in: range) {
             return false

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -1353,7 +1353,7 @@ extension TextView: TextInputViewDelegate {
     }
 
     func textInputView(_ view: TextInputView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        if textInputView.isRestoringPreviosulyDeletedText {
+        if textInputView.isRestoringPreviouslyDeletedText {
             // UIKit is inserting text to combine characters, for example to combine two Korean characters into one, and we do not want to interfere with that.
             return editorDelegate?.textView(self, shouldChangeTextIn: range, replacementText: text) ?? true
         } else if let characterPair = characterPairs.first(where: { $0.trailing == text }), skipInsertingTrailingComponent(of: characterPair, in: range) {

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -1353,7 +1353,7 @@ extension TextView: TextInputViewDelegate {
     }
 
     func textInputView(_ view: TextInputView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        if textInputView.isInsertingTextToCombineCharacters {
+        if textInputView.isRestoringPreviosulyDeletedText {
             // UIKit is inserting text to combine characters, for example to combine two Korean characters into one, and we do not want to interfere with that.
             return editorDelegate?.textView(self, shouldChangeTextIn: range, replacementText: text) ?? true
         } else if let characterPair = characterPairs.first(where: { $0.trailing == text }), skipInsertingTrailingComponent(of: characterPair, in: range) {


### PR DESCRIPTION
This PR fixes an issue where characters in a character pair may be deleted and reappear when writing text in Korean or other languages that combines characters.

The issue happens because UIKit performs the following flow when a user writes characters that are combined.

1. User presses the ㅇ key.
2. UIKit inserts the ㅇ character into the text.
3. User presses the ㅓ key.
4. UIKit calls `-deleteBackward()` to delete the ㅇ character.
5. UIKit calls `-deleteBackward()` to delete the character before the ㅇ character. I'm unsure why this is needed.
6. UIKit calls `-insertText(_:)`  to insert the character that was previously before the ㅇ character.
7. UIKit calls `-insertText(_:)`  to insert 어, which is the combined character.

Notice that `insertText(_:)` is never called with the ㅓ character. UIKit automatically detects that the new character and a previously inserted character should be combined and calls `-deleteBackward()` and `-insertText()` to achieve this.

The issue occurred as part of step 6. If the character before the ㅇ character was part of a character pair, for example a quotation mark, we would run our logic for character pairs with that that character again. This was not supposed to happen.

Unfortunately, there is no good way to detect that UIKit is performing the above seven steps. However, we can get close by making the following assumption:

> When a key on the keyboard is pressed to delete a character or insert a character, `-layoutSubviews()` is called immediately after.

This assumption seems to holder. However, `-layoutSubviews()` is not called between step 5 and 6 in the above flow. Therefore we can detect the case of characters being combined in `-insertText()` with the following logic.

1. Set `hasDeletedTextWithPendingLayoutSubviews  = true` in `-deleteBackward()`. This lets us know that we've deleted text and are expected `-layoutSubviews()` to be called.
2. Set `hasDeletedTextWithPendingLayoutSubviews = false` in `-layoutSubviews()` as we are no longer expecting `-layoutSubviews()` to be called.
3. Check if `hasDeletedTextWithPendingLayoutSubviews` equals `true` in `insertText(_:)`. If it does, that means `-insertText(_:)` was called immediately after `-deleteBackward()` with no call to `-layoutSubviews()` in between and we have successfully detected the case of restoring a character sequence. We let others know of this by setting `isRestoringPreviouslyDeletedText = true`.
4. Set `hasDeletedTextWithPendingLayoutSubviews = false` as we no longer need to keep track of this property.
5. Reset `isRestoringPreviouslyDeletedText` at the end of `insertText(_:)` to be ready for the next run,

### Old

https://user-images.githubusercontent.com/830995/199274645-1ad0d660-82f5-4f1a-8cce-ff455edd38c1.mp4

### New

https://user-images.githubusercontent.com/830995/199274399-b6f689a9-2ff2-44ee-bc78-ceb3750a2295.mp4