### PR TITLE
Supports injection.language and injection.content

### DIFF
--- a/Sources/Runestone/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterInjectedLanguageMapper.swift
+++ b/Sources/Runestone/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterInjectedLanguageMapper.swift
@@ -47,9 +47,9 @@ final class TreeSitterInjectedLanguageMapper {
 
 private extension TreeSitterCapture {
     var isTextLanguageName: Bool {
-        return name == "language"
+        return name == "language" || name == "injection.language"
     }
     var isTextContent: Bool {
-        return name == "content"
+        return name == "content" || name == "injection.content"
     }
 }


### PR DESCRIPTION
This PR adds support for injection.language and injection.content captures used in recent changes to [the Markdown parser](https://github.com/MDeiml/tree-sitter-markdown).