### PR TITLE
Fixes incorrect range of composed characters for Windows-style line breaks

### DIFF
--- a/Example/Example/Library/ProcessInfo+Helpers.swift
+++ b/Example/Example/Library/ProcessInfo+Helpers.swift
@@ -4,4 +4,8 @@ extension ProcessInfo {
     var disableTextPersistance: Bool {
         return environment["disableTextPersistance"] != nil
     }
+
+    var useCRLFLineEndings: Bool {
+        return environment["crlfLineEndings"] != nil
+    }
 }

--- a/Example/Example/Main/MainViewController.swift
+++ b/Example/Example/Main/MainViewController.swift
@@ -68,6 +68,9 @@ private extension MainViewController {
         let themeSetting = UserDefaults.standard.theme
         let theme = themeSetting.makeTheme()
         let state = TextViewState(text: text, theme: theme, language: .javaScript)
+        if ProcessInfo.processInfo.useCRLFLineEndings {
+            contentView.textView.lineEndings = .crlf
+        }
         contentView.textView.editorDelegate = self
         contentView.textView.setState(state)
     }

--- a/Example/ExampleUITests/KoreanInputTests.swift
+++ b/Example/ExampleUITests/KoreanInputTests.swift
@@ -125,4 +125,18 @@ final class KoreanInputTests: XCTestCase {
         app.keys["ㅓ"].tap()
         XCTAssertEqual(app.textView?.value as? String, "어어어\n\"어어어\"\n어어어")
     }
+
+    func testInsertingKoreanCharactersInTextWithCRLFLineEndings() throws {
+        let app = XCUIApplication().disablingTextPersistance().usingCRLFLineEndings()
+        app.launch()
+        app.textView?.tap()
+        app.typeText("테스트")
+        app.buttons["Return"].tap()
+        app.typeText("TEST")
+        app.buttons["Return"].tap()
+        app.keys["ㅇ"].tap()
+        app.keys["ㅓ"].tap()
+        app.keys["ㅍ"].tap()
+        XCTAssertEqual(app.textView?.value as? String, "테스트\r\nTEST\r\n엎")
+    }
 }

--- a/Example/ExampleUITests/XCUIApplication+Helpers.swift
+++ b/Example/ExampleUITests/XCUIApplication+Helpers.swift
@@ -2,6 +2,7 @@ import XCTest
 
 private enum EnvironmentKey {
     static let disableTextPersistance = "disableTextPersistance"
+    static let crlfLineEndings = "crlfLineEndings"
 }
 
 extension XCUIApplication {
@@ -19,6 +20,13 @@ extension XCUIApplication {
     func disablingTextPersistance() -> Self {
         var newLaunchEnvironment = launchEnvironment
         newLaunchEnvironment[EnvironmentKey.disableTextPersistance] = "1"
+        launchEnvironment = newLaunchEnvironment
+        return self
+    }
+
+    func usingCRLFLineEndings() -> Self {
+        var newLaunchEnvironment = launchEnvironment
+        newLaunchEnvironment[EnvironmentKey.crlfLineEndings] = "1"
         launchEnvironment = newLaunchEnvironment
         return self
     }

--- a/Sources/Runestone/Library/NSString+Helpers.swift
+++ b/Sources/Runestone/Library/NSString+Helpers.swift
@@ -39,7 +39,7 @@ extension NSString {
         let defaultRange = rangeOfComposedCharacterSequences(for: range)
         let candidateCRLFRange = NSRange(location: defaultRange.location - 1, length: 2)
         if candidateCRLFRange.location >= 0 && candidateCRLFRange.upperBound <= length && isCRLFLineEnding(in: candidateCRLFRange) {
-            return candidateCRLFRange
+            return NSRange(location: defaultRange.location - 1, length: defaultRange.length + 1)
         } else {
             return defaultRange
         }


### PR DESCRIPTION
This PR fixes an issue where Runestone would not compute the correct range of composed characters for CRLF (Windows-style) line breaks.

The issue was evident when entering Korean characters in a file that used Windows-style line breaks, hence the UI test which tests with Korean characters.