### PR TITLE
Add showMenuAfterNavigatingToHighlightedRange flag

### DIFF
--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -568,6 +568,8 @@ open class TextView: UIScrollView {
             textInputView.lineEndings = newValue
         }
     }
+    /// When enabled the text view will present a menu with actions actions such as Copy and Replace after navigating to a highlighted range.
+    public var showMenuAfterNavigatingToHighlightedRange = true
 #if compiler(>=5.7)
     /// A boolean value that enables a text view’s built-in find interaction.
     ///
@@ -1415,7 +1417,9 @@ extension TextView: HighlightNavigationControllerDelegate {
         scrollRangeToVisible(range)
         textInputView.selectedTextRange = IndexedRange(range)
         _ = textInputView.becomeFirstResponder()
-        textInputView.presentEditMenuForText(in: range)
+        if showMenuAfterNavigatingToHighlightedRange {
+            textInputView.presentEditMenuForText(in: range)
+        }
         switch highlightNavigationRange.loopMode {
         case .previousGoesToLast:
             editorDelegate?.textViewDidLoopToLastHighlightedRange(self)


### PR DESCRIPTION
PR for https://github.com/simonbs/Runestone/issues/254
I've simply added a flag and use it when selecting a range to choose if to show the edit menu or not

Sorry Simon, I'm making a new pull request because I messed up the last one with the GitHub auto-resolve 😅
This time everything should be ok!
 