### PR TITLE
Fixes y-position of firstRect

### DIFF
--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -439,7 +439,8 @@ extension LineController {
                 let finalIndex = min(lineRange.location + lineRange.length, range.location + range.length)
                 let xStart = CTLineGetOffsetForStringIndex(line, index, nil)
                 let xEnd = CTLineGetOffsetForStringIndex(line, finalIndex, nil)
-                return CGRect(x: xStart, y: lineFragment.yPosition, width: xEnd - xStart, height: lineFragment.scaledSize.height)
+                let yPosition = lineFragment.yPosition + (lineFragment.scaledSize.height - lineFragment.baseSize.height) / 2
+                return CGRect(x: xStart, y: yPosition, width: xEnd - xStart, height: lineFragment.baseSize.height)
             }
         }
         return CGRect(x: 0, y: 0, width: 0, height: estimatedLineFragmentHeight * lineFragmentHeightMultiplier)


### PR DESCRIPTION
This PR fixes the Y-position of rects returned from `firstRect(for:)`. These rectangles are used when UIKit performs auto completion.