### PR TITLE
Fixes placement of drawn invisible characters

### DIFF
--- a/Sources/Runestone/TextView/LineController/LineFragmentRenderer.swift
+++ b/Sources/Runestone/TextView/LineController/LineFragmentRenderer.swift
@@ -106,8 +106,10 @@ private extension LineFragmentRenderer {
 
     private func drawInvisibleCharacters(in string: String) {
         let textRange = CTLineGetStringRange(lineFragment.line)
-        for (indexInLineFragment, substring) in string.enumerated() {
+        var indexInLineFragment = 0
+        for substring in string {
             let indexInLine = textRange.location + indexInLineFragment
+            indexInLineFragment += substring.utf16.count
             if invisibleCharacterConfiguration.showSpaces && substring == Symbol.Character.space {
                 draw(invisibleCharacterConfiguration.spaceSymbol, at: .character(indexInLine))
             } else if invisibleCharacterConfiguration.showNonBreakingSpaces && substring == Symbol.Character.nonBreakingSpace {


### PR DESCRIPTION
This PR fixes an issue where invisible characters were drawn incorrectly on line fragments containing a composed characters, such as emojis.

|Before|After|
|-|-|
|<img width="375" src="https://user-images.githubusercontent.com/830995/218504420-96a995bb-162c-4449-8bc3-ffcac3b51d8f.png"/>|<img width="375" src="https://user-images.githubusercontent.com/830995/218504406-b7e471cb-91fa-4b55-97ba-38bc663bfcbe.png"/>|
