### PR TITLE
Fix textViewDidChange was not being called

### DIFF
--- a/Sources/Runestone/TextView/Core/Mac/TextView_Mac.swift
+++ b/Sources/Runestone/TextView/Core/Mac/TextView_Mac.swift
@@ -732,6 +732,7 @@ extension TextView: TextViewControllerDelegate {
     func textViewControllerDidChangeText(_ textViewController: TextViewController) {
         caretView.delayBlinkIfNeeded()
         updateCaretFrame()
+        editorDelegate?.textViewDidChange(self)
     }
 
     func textViewController(_ textViewController: TextViewController, didChangeSelectedRange selectedRange: NSRange?) {


### PR DESCRIPTION
I noticed in the Mac version textViewDidChange was not being called on the editor delegate. I added the call to this in the same way that it was being done in TextView_iOS. I am not sure if this was intentional or an oversight but seams to be working now. 