### PR TITLE
Removed Tree-Sitter from Runestone itself

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tree-sitter"]
-	path = tree-sitter
-	url = https://github.com/tree-sitter/tree-sitter.git

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,7 @@
         "package": "TreeSitter",
         "repositoryURL": "https://github.com/tree-sitter/tree-sitter",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "9fd128ed604bb63348281bd4ac0d99705e713147",
           "version": null
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "TreeSitter",
+        "repositoryURL": "https://github.com/ActuallyTaylor/tree-sitter-spm",
+        "state": {
+          "branch": "master",
+          "revision": "3860f9e8c683a730a53cd6fd594ff2d8cdc4c222",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "TreeSitter",
-        "repositoryURL": "https://github.com/ActuallyTaylor/tree-sitter-spm",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter",
         "state": {
           "branch": "master",
-          "revision": "3860f9e8c683a730a53cd6fd594ff2d8cdc4c222",
+          "revision": "9fd128ed604bb63348281bd4ac0d99705e713147",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Pins tree-sitter to the merge commit when SPM was added. This will be changed to pin to a release, when a release is created that includes SPM.
-        .package(url: "https://github.com/tree-sitter/tree-sitter", .revision("9fd128ed604bb63348281bd4ac0d99705e713147")),
+        .package(url: "https://github.com/tree-sitter/tree-sitter", .revision("9fd128ed604bb63348281bd4ac0d99705e713147"))
     ],
     targets: [
         .target(name: "Runestone", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,11 @@ let package = Package(
         .library(name: "Runestone", targets: ["Runestone"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ActuallyTaylor/tree-sitter-spm", branch: "master")
+        .package(url: "https://github.com/tree-sitter/tree-sitter", branch: "master")
     ],
     targets: [
         .target(name: "Runestone", dependencies: [
-            .product(name: "TreeSitter", package: "tree-sitter-spm")
+            .product(name: "TreeSitter", package: "tree-sitter")
             ], resources: [.process("TextView/Appearance/Theme.xcassets")]),
         .target(name: "TestTreeSitterLanguages", cSettings: [.unsafeFlags(["-w"])]),
         .testTarget(name: "RunestoneTests", dependencies: ["Runestone", "TestTreeSitterLanguages"])

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .iOS(.v14)
     ],
     products: [
-        .library(name: "Runestone", targets: ["Runestone"]),
+        .library(name: "Runestone", targets: ["Runestone"])
     ],
     dependencies: [
         .package(url: "https://github.com/tree-sitter/tree-sitter", branch: "master")
@@ -18,7 +18,7 @@ let package = Package(
     targets: [
         .target(name: "Runestone", dependencies: [
             .product(name: "TreeSitter", package: "tree-sitter")
-            ], resources: [.process("TextView/Appearance/Theme.xcassets")]),
+        ], resources: [.process("TextView/Appearance/Theme.xcassets")]),
         .target(name: "TestTreeSitterLanguages", cSettings: [.unsafeFlags(["-w"])]),
         .testTarget(name: "RunestoneTests", dependencies: ["Runestone", "TestTreeSitterLanguages"])
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
         .library(name: "Runestone", targets: ["Runestone"])
     ],
     dependencies: [
-        .package(url: "https://github.com/tree-sitter/tree-sitter", branch: "master")
+        // Pins tree-sitter to the merge commit when SPM was added. This will be changed to pin to a release, when a release is created that includes SPM.
+        .package(url: "https://github.com/tree-sitter/tree-sitter", .revision("9fd128ed604bb63348281bd4ac0d99705e713147")),
     ],
     targets: [
         .target(name: "Runestone", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,35 +10,15 @@ let package = Package(
         .iOS(.v14)
     ],
     products: [
-        .library(name: "Runestone", targets: ["Runestone"])
+        .library(name: "Runestone", targets: ["Runestone"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ActuallyTaylor/tree-sitter-spm", branch: "master")
     ],
     targets: [
-        .target(name: "Runestone",
-                dependencies: ["TreeSitter"],
-                resources: [.process("TextView/Appearance/Theme.xcassets")]),
-        .target(name: "TreeSitter",
-                path: "tree-sitter/lib",
-                exclude: [
-                    "binding_rust",
-                    "binding_web",
-                    "Cargo.toml",
-                    "README.md",
-                    "src/unicode/README.md",
-                    "src/unicode/LICENSE",
-                    "src/unicode/ICU_SHA",
-                    "src/get_changed_ranges.c",
-                    "src/tree_cursor.c",
-                    "src/stack.c",
-                    "src/node.c",
-                    "src/lexer.c",
-                    "src/parser.c",
-                    "src/language.c",
-                    "src/alloc.c",
-                    "src/subtree.c",
-                    "src/tree.c",
-                    "src/query.c"
-                ],
-                sources: ["src/lib.c"]),
+        .target(name: "Runestone", dependencies: [
+            .product(name: "TreeSitter", package: "tree-sitter-spm")
+            ], resources: [.process("TextView/Appearance/Theme.xcassets")]),
         .target(name: "TestTreeSitterLanguages", cSettings: [.unsafeFlags(["-w"])]),
         .testTarget(name: "RunestoneTests", dependencies: ["Runestone", "TestTreeSitterLanguages"])
     ]


### PR DESCRIPTION
This pull request removes the Tree-Sitter subdirectory from Runestone in favor of a SPM dependency. Everything functions exactly the same as before.

Currently, this pull request uses the repository [https://github.com/ActuallyTaylor/tree-sitter-spm](https://github.com/ActuallyTaylor/tree-sitter-spm) which is a fork of the original Tree-Sitter repository with SPM support added. This is not ideal, as it is not the main repository of Tree-Sitter. To remedy this, I have created a pull request on Tree-Sitter itself [Tree-Sitter PR #2311](https://github.com/tree-sitter/tree-sitter/pull/2311) that once added, will bring SPM support to the main branch.