### PR TITLE
Replaces TextView.lengthOfInitallyLongestLine with TextViewState.lengthOfLongestLine

### DIFF
--- a/Sources/Runestone/Documentation.docc/Extensions/TextView.md
+++ b/Sources/Runestone/Documentation.docc/Extensions/TextView.md
@@ -40,7 +40,6 @@
 
 - ``isLineWrappingEnabled``
 - ``lineBreakMode``
-- ``lengthOfInitallyLongestLine``
 
 ### Invisible Characters
 

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -521,12 +521,6 @@ open class TextView: UIScrollView {
             }
         }
     }
-    /// The length of the line that was longest when opening the document.
-    ///
-    /// This will return nil if the line is no longer available. The value will not be kept updated as the text is changed. The value can be used to determine if a document contains a very long line in which case the performance may be degraded when editing the line.
-    public var lengthOfInitallyLongestLine: Int? {
-        textInputView.lineManager.initialLongestLine?.data.totalLength
-    }
     /// Ranges in the text to be highlighted. The color defined by the background will be drawen behind the text.
     public var highlightedRanges: [HighlightedRange] {
         get {

--- a/Sources/Runestone/TextView/Core/TextViewState.swift
+++ b/Sources/Runestone/TextView/Core/TextViewState.swift
@@ -14,7 +14,7 @@ public final class TextViewState {
     /// The information provided by the detected strategy can be used to update the ``TextView/indentStrategy`` on the text view to align with the existing strategy in a text.
     public private(set) var detectedIndentStrategy: DetectedIndentStrategy = .unknown
 
-    /// Line endings detected in the dtext.
+    /// Line endings detected in the text.
     ///
     /// The information pvoided by the detected line endings can be used to update the ``TextView/lineEndings`` on the text view to align with the existing line endings in a text.
     ///

--- a/Sources/Runestone/TextView/Core/TextViewState.swift
+++ b/Sources/Runestone/TextView/Core/TextViewState.swift
@@ -21,6 +21,9 @@ public final class TextViewState {
     /// The value is `nil` if the line ending cannot be detected.
     public private(set) var detectedLineEndings: LineEnding?
 
+    /// The length of the longest line.
+    public private(set) var lengthOfLongestLine: Int?
+
     /// Creates state that can be passed to an instance of ``TextView``.
     /// - Parameters:
     ///   - text: The text to display in the text view.
@@ -60,6 +63,7 @@ private extension TextViewState {
         lineManager.estimatedLineHeight = theme.font.totalLineHeight
         lineManager.rebuild()
         languageMode.parse(nsString)
+        lengthOfLongestLine = lineManager.initialLongestLine?.data.totalLength
         detectedIndentStrategy = languageMode.detectIndentStrategy()
         let lineEndingDetector = LineEndingDetector(lineManager: lineManager, stringView: stringView)
         detectedLineEndings = lineEndingDetector.detect()


### PR DESCRIPTION
Replaces `lengthOfInitallyLongestLine` on TextView with `lengthOfLongestLine` on TextViewState. Exposing this information through the TextView type never felt right but exposing it through TextViewState seems to fit well with its `detectedIndentStrategy` and `detectedLineEndings` properties.