### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,5 +1,3 @@
 version: 1
-builder:
-  configs:
-  - platform: ios
-    documentation_targets: [Runestone]
+external_links:
+  documentation: "https://docs.runestone.app"

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,5 @@
-version: 1
-external_links:
-  documentation: "https://docs.runestone.app"
+builder:
+  configs:
+  - platform: ios
+    documentation_targets: [Runestone]
+    swift_version: 5.9


### PR DESCRIPTION
Hi Simon!

Our documentation smoke test started failing yesterday, indicating that Runestone's doc generation isn't working anymore. I've recorded some details in this issue here: https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2504 but I've also seen that you're actually hosting your own docs.

It might be better to simply link to your docs than to generate them in SPI? This PR would sort that out :)