### PR TITLE
Pins against fork of Tree-sitter

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "TreeSitter",
-        "repositoryURL": "https://github.com/tree-sitter/tree-sitter",
+        "repositoryURL": "https://github.com/simonbs/tree-sitter",
         "state": {
           "branch": null,
-          "revision": "9fd128ed604bb63348281bd4ac0d99705e713147",
-          "version": null
+          "revision": "f88ae4ebe351d8aa99c31a17111607017d805118",
+          "version": "0.20.9-beta-1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             .unsafeFlags(["-w"])
         ]),
         .testTarget(name: "RunestoneTests", dependencies: [
-            "Runestone", 
+            "Runestone",
             "TestTreeSitterLanguages"
         ])
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Tree-sitter supports SPM but as of writing this, the official Tree-sitter repository has no versions published that contains the Package.swift file. Therefore, we depend on a fork of Tree-sitter that has a version published.
         // We will pin against the official version of Tree-sitter as soon as a new version is published.
-        .package(url: "https://github.com/simonbs/tree-sitter", from: "0.20.9-beta.1")
+        .package(url: "https://github.com/simonbs/tree-sitter", from: "0.20.9-beta-1")
     ],
     targets: [
         .target(name: "Runestone", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,15 @@ let package = Package(
     targets: [
         .target(name: "Runestone", dependencies: [
             .product(name: "TreeSitter", package: "tree-sitter")
-        ], resources: [.process("TextView/Appearance/Theme.xcassets")]),
-        .target(name: "TestTreeSitterLanguages", cSettings: [.unsafeFlags(["-w"])]),
-        .testTarget(name: "RunestoneTests", dependencies: ["Runestone", "TestTreeSitterLanguages"])
+        ], resources: [
+            .process("TextView/Appearance/Theme.xcassets")
+        ]),
+        .target(name: "TestTreeSitterLanguages", cSettings: [
+            .unsafeFlags(["-w"])
+        ]),
+        .testTarget(name: "RunestoneTests", dependencies: [
+            "Runestone", 
+            "TestTreeSitterLanguages"
+        ])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Pins tree-sitter to the merge commit when SPM was added. This will be changed to pin to a release, when a release is created that includes SPM.
-        .package(url: "https://github.com/tree-sitter/tree-sitter", .revision("9fd128ed604bb63348281bd4ac0d99705e713147"))
+        .package(url: "https://github.com/tree-sitter/tree-sitter", branch: "master")
     ],
     targets: [
         .target(name: "Runestone", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,9 @@ let package = Package(
         .library(name: "Runestone", targets: ["Runestone"])
     ],
     dependencies: [
-        // Pins tree-sitter to the merge commit when SPM was added. This will be changed to pin to a release, when a release is created that includes SPM.
-        .package(url: "https://github.com/tree-sitter/tree-sitter", branch: "master")
+        // Tree-sitter supports SPM but as of writing this, the official Tree-sitter repository has no versions published that contains the Package.swift file. Therefore, we depend on a fork of Tree-sitter that has a version published.
+        // We will pin against the official version of Tree-sitter as soon as a new version is published.
+        .package(url: "https://github.com/simonbs/tree-sitter", from: "0.20.9-beta.1")
     ],
     targets: [
         .target(name: "Runestone", dependencies: [


### PR DESCRIPTION
Tree-sitter [now supports SPM](https://github.com/tree-sitter/tree-sitter/pull/2311) but as of writing this, the official Tree-sitter repository has no versions published that contains the Package.swift file. Therefore, we depend on [my fork of Tree-sitter](https://github.com/simonbs/tree-sitter/) that has version 0.20.9-beta-1 published, which is exactly the same code base as [the official version 0.20.8](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.20.8) but with [the commit that adds SPM](https://github.com/tree-sitter/tree-sitter/commit/9fd128ed604bb63348281bd4ac0d99705e713147) support cherry-picked.

We will pin against the official version of Tree-sitter as soon as a new version is published.