### PR TITLE
Revert back to default Swift version for doc building

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,4 +3,3 @@ builder:
   configs:
   - platform: ios
     documentation_targets: [Runestone]
-    swift_version: 5.9


### PR DESCRIPTION
Sorry for the back and forth, Simon! 🙈

Turns out Swift 5.9 isn't actually required to get the docs to build again. And by staying on the default it'll move forward to 5.9 (or higher) whenever we change the default version we're building docs with. So not specifying it is better.