### PR TITLE
Adds workaround for caret not appearing on iOS 17

### DIFF
--- a/Sources/Runestone/Library/UITextInput+Helpers.swift
+++ b/Sources/Runestone/Library/UITextInput+Helpers.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+@available(iOS 17, *)
+extension UITextInput where Self: NSObject {
+    var sbs_textSelectionDisplayInteraction: UITextSelectionDisplayInteraction? {
+        let interactionAssistantKey = "int" + "ssAnoitcare".reversed() + "istant"
+        let selectionViewManagerKey = "les_".reversed() + "ection" + "reganaMweiV".reversed()
+        guard responds(to: Selector(interactionAssistantKey)) else {
+            return nil
+        }
+        guard let interactionAssistant = value(forKey: interactionAssistantKey) as? AnyObject else {
+            return nil
+        }
+        guard interactionAssistant.responds(to: Selector(selectionViewManagerKey)) else {
+            return nil
+        }
+        return interactionAssistant.value(forKey: selectionViewManagerKey) as? UITextSelectionDisplayInteraction
+    }
+}

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -1238,6 +1238,10 @@ private extension TextView {
             isInputAccessoryViewEnabled = true
             textInputView.removeInteraction(nonEditableTextInteraction)
             textInputView.addInteraction(editableTextInteraction)
+            if #available(iOS 17, *) {
+                // Workaround a bug where the caret does not appear until the user taps again on iOS 17 (FB12622609).
+                textInputView.sbs_textSelectionDisplayInteraction?.isActivated = true
+            }
         }
     }
 


### PR DESCRIPTION
This works around an issue where the caret does not appear when editing starts on iOS 17 until the user have tapped the text view again. 

This is a regression in UITextInteraction and other developers of text editors are seeing the same issue.

I have filed this as feedback to Apple on July 15th, 2023 but have yet to hear back from them (FB12622609).

The issue seems to be caused by the UITextSelectionDisplayInteraction that is automatically installed by UITextInteraction not being active initially.