### PR TITLE
Pin to upstream Tree-sitter revision

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "TreeSitter",
-        "repositoryURL": "https://github.com/simonbs/tree-sitter",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter",
         "state": {
           "branch": null,
-          "revision": "f88ae4ebe351d8aa99c31a17111607017d805118",
-          "version": "0.20.9-beta-1"
+          "revision": "3b0159d25559b603af566ade3c83d930bf466db1",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,7 @@ let package = Package(
         .library(name: "Runestone", targets: ["Runestone"])
     ],
     dependencies: [
-        // Tree-sitter supports SPM but as of writing this, the official Tree-sitter repository has no versions published that contains the Package.swift file. Therefore, we depend on a fork of Tree-sitter that has a version published.
-        // We will pin against the official version of Tree-sitter as soon as a new version is published.
-        .package(url: "https://github.com/simonbs/tree-sitter", from: "0.20.9-beta-1")
+        .package(url: "https://github.com/tree-sitter/tree-sitter", revision: "3b0159d25559b603af566ade3c83d930bf466db1")
     ],
     targets: [
         .target(name: "Runestone", dependencies: [


### PR DESCRIPTION
This resolves a handful of buffer overflows related to Tree-sitter that were resolved in the upstream version of this repo, namely within https://github.com/tree-sitter/tree-sitter/pull/2408.

Additionally, this latest version has patches for a number of bug fixes, including seg faults and out-of-bounds accesses.

Compare: https://github.com/simonbs/tree-sitter/compare/v0.20.9-beta-1...tree-sitter:tree-sitter:3b0159d25559b603af566ade3c83d930bf466db1