### PR TITLE
Uses tree-sitter v0.20.9-beta-2 from fork

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/simonbs/tree-sitter",
         "state": {
           "branch": null,
-          "revision": "f88ae4ebe351d8aa99c31a17111607017d805118",
-          "version": "0.20.9-beta-1"
+          "revision": "8456f7eb7a70addb3c0af8a757f1997ae9af3ed6",
+          "version": "0.20.9-beta-2"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/simonbs/tree-sitter",
         "state": {
           "branch": null,
-          "revision": "f88ae4ebe351d8aa99c31a17111607017d805118",
-          "version": "0.20.9-beta-1"
+          "revision": "8456f7eb7a70addb3c0af8a757f1997ae9af3ed6",
+          "version": "0.20.9-beta-2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Tree-sitter supports SPM but as of writing this, the official Tree-sitter repository has no versions published that contains the Package.swift file. Therefore, we depend on a fork of Tree-sitter that has a version published.
         // We will pin against the official version of Tree-sitter as soon as a new version is published.
-        .package(url: "https://github.com/simonbs/tree-sitter", from: "0.20.9-beta-1")
+        .package(url: "https://github.com/simonbs/tree-sitter", from: "0.20.9-beta-2")
     ],
     targets: [
         .target(name: "Runestone", dependencies: [


### PR DESCRIPTION
This PR depends on Tree-sitter v0.20.9-beta-2 in [my private fork of tree-sitter](https://github.com/simonbs/tree-sitter). The motivation for updating Tree-sitter and pointing at a private fork is described in #324.