### PR TITLE
Configure matrix for testing against Xcode 14 and 15

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build and test
     runs-on: macos-13
+    continue-on-error: true
     strategy:
       matrix:
         include:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,12 +12,19 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.1.app/Contents/Developer
 jobs:
   build:
     name: Build and test
     runs-on: macos-13
+    strategy:
+      matrix:
+        include:
+          - destination: iPhone 15 Pro
+            xcode: 15.0.1
+          - destination: iPhone 14 Pro
+            xcode: 14.3.1
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer    
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -28,10 +35,10 @@ jobs:
           xcodebuild build-for-testing\
             -scheme Runestone\
             -sdk iphonesimulator\
-            -destination "platform=iOS Simulator,name=iPhone 15 Pro,OS=latest"
+            -destination "platform=iOS Simulator,name=${{ matrix.destination }},OS=latest"
       - name: Test
         run: |
           xcodebuild test-without-building\
             -scheme Runestone\
             -sdk iphonesimulator\
-            -destination "platform=iOS Simulator,name=iPhone 15 Pro,OS=latest"
+            -destination "platform=iOS Simulator,name=${{ matrix.destination }},OS=latest"

--- a/.github/workflows/build_example_project.yml
+++ b/.github/workflows/build_example_project.yml
@@ -10,12 +10,19 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.1.app/Contents/Developer
 jobs:
   build:
     name: Build example project
     runs-on: macos-13
+    strategy:
+      matrix:
+        include:
+          - destination: iPhone 15 Pro
+            xcode: 15.0.1
+          - destination: iPhone 14 Pro
+            xcode: 14.3.1
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer    
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,4 +34,4 @@ jobs:
             -project Example/Example.xcodeproj\
             -scheme Example\
             -sdk iphonesimulator\
-            -destination "platform=iOS Simulator,name=iPhone 15 Pro,OS=latest"
+            -destination "platform=iOS Simulator,name=${{ matrix.destination }},OS=latest"

--- a/.github/workflows/build_example_project.yml
+++ b/.github/workflows/build_example_project.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Build example project
     runs-on: macos-13
+    continue-on-error: true
     strategy:
       matrix:
         include:


### PR DESCRIPTION
While updating Runestone within GitHub for iOS, I noticed that the codebase was updated to require Xcode 15. Our codebase still runs tests against Xcode 14, while we work with Apple on [regressions caused in Xcode 15 in CI environments](https://discuss.circleci.com/t/severe-performance-problems-with-xcode-15/49205).

This configures Actions to run tests for each variant of Xcode, which should help us catch new additions requiring new versions of Xcode.

> [!NOTE]  
> The Xcode 14 build will fail for now, until we add compile-time checks for the new APIs that require Xcode 15. I'll do that in a follow-up!
