### PR TITLE
Fixes navigation between word boundaries

### DIFF
--- a/Sources/Runestone/TextView/Core/TextInputStringTokenizer.swift
+++ b/Sources/Runestone/TextView/Core/TextInputStringTokenizer.swift
@@ -3,6 +3,10 @@ import UIKit
 final class TextInputStringTokenizer: UITextInputStringTokenizer {
     var lineManager: LineManager
     var stringView: StringView
+    // Used to ensure we can workaround bug where multi-stage input, like when entering Korean text
+    // does not work properly. If we do not treat navigation between word boundies as a special case then
+    // navigating with Shift + Option + Arrow Keys followed by Shift + Arrow Keys will not work correctly.
+    var didCallPositionFromPositionToWordBoundary = false
 
     private let lineControllerStorage: LineControllerStorage
     private var newlineCharacters: [Character] {
@@ -206,6 +210,7 @@ private extension TextInputStringTokenizer {
         guard let indexedPosition = position as? IndexedPosition else {
             return nil
         }
+        didCallPositionFromPositionToWordBoundary = true
         let location = indexedPosition.index
         let alphanumerics = CharacterSet.alphanumerics
         if direction.isForward {


### PR DESCRIPTION
This PR fixes an issue where text selection started behaving incorrectly after navigating between word boundaries. The issue could be reproduced using the following steps:

> Shift-arrow up a couple lines, then keeping shift down, option-left or option-right to select out a few words, and then try to adjust the selection with right or left arrows. That's where the selection starts happening at origin instead of in the direction of expansion/contraction.

The bug seems to originate from the workaround that ensures multi-stage text input, such as when writing Korean, works properly. The changes in this PR ensures that both multi-stage text input and navigating between word boundaries work correctly.