### PR TITLE
Only allows patches of Tree-sitter dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "Runestone", targets: ["Runestone"])
     ],
     dependencies: [
-        .package(url: "https://github.com/tree-sitter/tree-sitter", from: "0.20.9")
+        .package(url: "https://github.com/tree-sitter/tree-sitter", .upToNextMinor(from: "0.20.9"))
     ],
     targets: [
         .target(name: "Runestone", dependencies: [


### PR DESCRIPTION
[As discovered by Pasi Salenius](https://infosec.exchange/@pasi/111987877220362030), Tree-sitter 0.21.0 moves the lib/include/tree_sitter/parser.h to the src folder, making the TSLanguage definition unavailable to Runestone.

This is a breaking change that I'll need time to look into how we can address best. My intuition is that we need to modify the Package.swift manifest of the Tree-sitter package to expose the parser.h.

In the mean time, Runestone will stay on Tree-sitter 0.20.x.