### PR TITLE
Adds privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .target(name: "Runestone", dependencies: [
             .product(name: "TreeSitter", package: "tree-sitter")
         ], resources: [
+            .copy("PrivacyInfo.xcprivacy"),
             .process("TextView/Appearance/Theme.xcassets")
         ]),
         .target(name: "TestTreeSitterLanguages", cSettings: [

--- a/Sources/Runestone/PrivacyInfo.xcprivacy
+++ b/Sources/Runestone/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+</dict>
+</plist>


### PR DESCRIPTION
Adds a barebones privacy report. Runestone does not track anything or use any of the required reason APIs.