### PR TITLE
Adds DefaultStringAttributes

### DIFF
--- a/Sources/Runestone/Library/DefaultStringAttributes.swift
+++ b/Sources/Runestone/Library/DefaultStringAttributes.swift
@@ -1,0 +1,41 @@
+import Foundation
+import UIKit
+
+struct DefaultStringAttributes {
+    private let textColor: UIColor
+    private let font: UIFont
+    private let kern: CGFloat
+    private let tabWidth: CGFloat
+    private let lineHeightMultiplier: CGFloat
+
+    init(
+        textColor: UIColor,
+        font: UIFont,
+        kern: CGFloat,
+        tabWidth: CGFloat,
+        lineHeightMultiplier: CGFloat = 1
+    ) {
+        self.textColor = textColor
+        self.font = font
+        self.kern = kern
+        self.tabWidth = tabWidth
+        self.lineHeightMultiplier = lineHeightMultiplier
+    }
+
+    func apply(to attributedString: NSMutableAttributedString) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.tabStops = []
+        paragraphStyle.defaultTabInterval = tabWidth
+        paragraphStyle.lineHeightMultiple = lineHeightMultiplier
+        let range = NSRange(location: 0, length: attributedString.length)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: textColor,
+            .font: font,
+            .kern: kern as NSNumber,
+            .paragraphStyle: paragraphStyle
+        ]
+        attributedString.beginEditing()
+        attributedString.setAttributes(attributes, range: range)
+        attributedString.endEditing()
+    }
+}

--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -1623,9 +1623,7 @@ extension TextInputView: LineControllerStorageDelegate {
 // MARK: - LineControllerDelegate
 extension TextInputView: LineControllerDelegate {
     func lineSyntaxHighlighter(for lineController: LineController) -> LineSyntaxHighlighter? {
-        let syntaxHighlighter = languageMode.createLineSyntaxHighlighter()
-        syntaxHighlighter.kern = kern
-        return syntaxHighlighter
+        languageMode.createLineSyntaxHighlighter()
     }
 
     func lineControllerDidInvalidateLineWidthDuringAsyncSyntaxHighlight(_ lineController: LineController) {

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -64,7 +64,7 @@ final class LineController {
     var kern: CGFloat = 0 {
         didSet {
             if kern != oldValue {
-                syntaxHighlighter?.kern = kern
+                isDefaultAttributesInvalid = true
             }
         }
     }
@@ -240,22 +240,17 @@ private extension LineController {
     private func updateDefaultAttributesIfNecessary() {
         if isDefaultAttributesInvalid {
             if let input = createLineSyntaxHighlightInput() {
-                syntaxHighlighter?.setDefaultAttributes(on: input.attributedString)
+                let defaultStringAttributes = DefaultStringAttributes(
+                    textColor: theme.textColor,
+                    font: theme.font,
+                    kern: kern,
+                    tabWidth: tabWidth
+                )
+                defaultStringAttributes.apply(to: input.attributedString)
             }
-            updateParagraphStyle()
             isDefaultAttributesInvalid = false
             isSyntaxHighlightingInvalid = true
             isTypesetterInvalid = true
-        }
-    }
-
-    private func updateParagraphStyle() {
-        if let attributedString = attributedString {
-            let paragraphStyle = NSMutableParagraphStyle()
-            paragraphStyle.tabStops = []
-            paragraphStyle.defaultTabInterval = tabWidth
-            let range = NSRange(location: 0, length: attributedString.length)
-            attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
         }
     }
 

--- a/Sources/Runestone/TextView/LineController/LineSyntaxHighlighter.swift
+++ b/Sources/Runestone/TextView/LineController/LineSyntaxHighlighter.swift
@@ -23,24 +23,8 @@ final class LineSyntaxHighlighterInput {
 protocol LineSyntaxHighlighter: AnyObject {
     typealias AsyncCallback = (Result<Void, Error>) -> Void
     var theme: Theme { get set }
-    var kern: CGFloat { get set }
     var canHighlight: Bool { get }
-    func setDefaultAttributes(on attributedString: NSMutableAttributedString)
     func syntaxHighlight(_ input: LineSyntaxHighlighterInput)
     func syntaxHighlight(_ input: LineSyntaxHighlighterInput, completion: @escaping AsyncCallback)
     func cancel()
-}
-
-extension LineSyntaxHighlighter {
-    func setDefaultAttributes(on attributedString: NSMutableAttributedString) {
-        let entireRange = NSRange(location: 0, length: attributedString.length)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: theme.textColor,
-            .font: theme.font,
-            .kern: kern as NSNumber
-        ]
-        attributedString.beginEditing()
-        attributedString.setAttributes(attributes, range: entireRange)
-        attributedString.endEditing()
-    }
 }


### PR DESCRIPTION
Moves the default attributes from LineSyntaxHighlighter to a separate type named DefaultStringAttributes, making it easier to apply these attributes in elsewhere in the codebase.