### PR TITLE
Setting selectedRange updates caret position

### DIFF
--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -185,7 +185,7 @@ open class TextView: UIScrollView {
             }
         }
         set {
-            textInputView.selectedRange = newValue
+            textInputView.selectedTextRange = IndexedRange(newValue)
         }
     }
     /// The current selection range of the text view as a UITextRange.


### PR DESCRIPTION
Setting `selectedRange` would not update the displayed caret position. This PR fixes the issue which is also described in #335.