### PR TITLE
Add a lock around parse, to prevent concurrent access to the underlying parse tree.

### DIFF
--- a/Sources/Runestone/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterInternalLanguageMode.swift
+++ b/Sources/Runestone/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterInternalLanguageMode.swift
@@ -17,7 +17,7 @@ final class TreeSitterInternalLanguageMode: InternalLanguageMode {
     private let rootLanguageLayer: TreeSitterLanguageLayer
     private let operationQueue = OperationQueue()
     private let parseLock = NSLock()
-    
+
     init(language: TreeSitterInternalLanguage, languageProvider: TreeSitterLanguageProvider?, stringView: StringView, lineManager: LineManager) {
         self.stringView = stringView
         self.lineManager = lineManager

--- a/Sources/Runestone/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterInternalLanguageMode.swift
+++ b/Sources/Runestone/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterInternalLanguageMode.swift
@@ -16,7 +16,8 @@ final class TreeSitterInternalLanguageMode: InternalLanguageMode {
     private let lineManager: LineManager
     private let rootLanguageLayer: TreeSitterLanguageLayer
     private let operationQueue = OperationQueue()
-
+    private let parseLock = NSLock()
+    
     init(language: TreeSitterInternalLanguage, languageProvider: TreeSitterLanguageProvider?, stringView: StringView, lineManager: LineManager) {
         self.stringView = stringView
         self.lineManager = lineManager
@@ -37,7 +38,9 @@ final class TreeSitterInternalLanguageMode: InternalLanguageMode {
     }
 
     func parse(_ text: NSString) {
-        rootLanguageLayer.parse(text)
+        parseLock.withLock {
+            rootLanguageLayer.parse(text)
+        }
     }
 
     func parse(_ text: NSString, completion: @escaping ((Bool) -> Void)) {


### PR DESCRIPTION
The parse method in TreeSitterInternalLanguageMode is invoked directly by the 
TextInputView.string.setter method, which can happen concurrently with the
calls to parse(_ text: NSString, completion: @escaping ((Bool) -> Void)) which happen to
queue things into a dedicated thread.

This causes a double-free of the underlying structures and assorted other crashes.

I caught this using the "address sanitizer" as I was trying to use my SwiftUI wrapper for
Runestone, which would trigger this event.
