### PR TITLE
Allow TextLocation to be created

### DIFF
--- a/Sources/Runestone/TextView/Navigation/TextLocation.swift
+++ b/Sources/Runestone/TextView/Navigation/TextLocation.swift
@@ -7,6 +7,12 @@ public struct TextLocation: Hashable, Equatable {
     /// Column in the line.
     public let column: Int
 
+    /// Initializes TextLocation from the given line and column
+    public init (lineNumber: Int, column: Int) {
+        self.lineNumber = lineNumber
+        self.column = column
+    }
+    
     init(_ linePosition: LinePosition) {
         self.lineNumber = linePosition.row
         self.column = linePosition.column

--- a/Sources/Runestone/TextView/Navigation/TextLocation.swift
+++ b/Sources/Runestone/TextView/Navigation/TextLocation.swift
@@ -12,7 +12,7 @@ public struct TextLocation: Hashable, Equatable {
         self.lineNumber = lineNumber
         self.column = column
     }
-    
+
     init(_ linePosition: LinePosition) {
         self.lineNumber = linePosition.row
         self.column = linePosition.column


### PR DESCRIPTION
There is currently no way of creating a TextLocation from a row, column.   Even if that seems to have 
been the desire from a previous PR:

https://github.com/simonbs/Runestone/pull/138

This allows me to create TextLocations, which in turn let me gets offsets, which in turn allow me to get screen coordinates from a given position.