### PR TITLE
Fix build with Xcode 16

### DIFF
--- a/Sources/Runestone/Library/UITextInput+Helpers.swift
+++ b/Sources/Runestone/Library/UITextInput+Helpers.swift
@@ -6,7 +6,7 @@ import UIKit
 extension UITextInput where Self: NSObject {
     var sbs_textSelectionDisplayInteraction: UITextSelectionDisplayInteraction? {
         let interactionAssistantKey = "int" + "ssAnoitcare".reversed() + "istant"
-        let selectionViewManagerKey = "les_".reversed() + "ection" + "reganaMweiV".reversed()
+        let selectionViewManagerKey: String = "les_".reversed() + "ection" + "reganaMweiV".reversed()
         guard responds(to: Selector(interactionAssistantKey)) else {
             return nil
         }


### PR DESCRIPTION
Prior to this, Xcode 16 was unable to infer the type of the variable (while Xcode 15 was), so the lookup to `reversed()` was ambiguous.

This adds `String` as the inferred type, so that the call to `reversed()` is no longer ambiguous.

<img width="1244" alt="Screenshot 2024-06-10 at 5 38 12 PM" src="https://github.com/simonbs/Runestone/assets/1051453/f69905f8-afb2-419e-9ba1-8bf39e52ab77">
