### PR TITLE
Avoid creating multiple instances of `DefaultTheme`.

### DIFF
--- a/Sources/Runestone/Library/UITextInput+Helpers.swift
+++ b/Sources/Runestone/Library/UITextInput+Helpers.swift
@@ -6,7 +6,7 @@ import UIKit
 extension UITextInput where Self: NSObject {
     var sbs_textSelectionDisplayInteraction: UITextSelectionDisplayInteraction? {
         let interactionAssistantKey = "int" + "ssAnoitcare".reversed() + "istant"
-        let selectionViewManagerKey = "les_".reversed() + "ection" + "reganaMweiV".reversed()
+        let selectionViewManagerKey: String = "les_".reversed() + "ection" + "reganaMweiV".reversed()
         guard responds(to: Selector(interactionAssistantKey)) else {
             return nil
         }

--- a/Sources/Runestone/StringSyntaxHighlighter.swift
+++ b/Sources/Runestone/StringSyntaxHighlighter.swift
@@ -27,7 +27,7 @@ public final class StringSyntaxHighlighter {
     ///   - language: The language to use when parsing the text
     ///   - languageProvider: Object that can provide embedded languages on demand. A strong reference will be stored to the language provider..
     public init(
-        theme: Theme = DefaultTheme(),
+        theme: Theme = DefaultTheme.share,
         language: TreeSitterLanguage,
         languageProvider: TreeSitterLanguageProvider? = nil
     ) {

--- a/Sources/Runestone/TextView/Appearance/DefaultTheme.swift
+++ b/Sources/Runestone/TextView/Appearance/DefaultTheme.swift
@@ -18,6 +18,8 @@ public final class DefaultTheme: Runestone.Theme {
     public let selectionColor = UIColor(themeColorNamed: "selection")
 
     public init() {}
+    
+    public static let share = DefaultTheme()
 
     // swiftlint:disable:next cyclomatic_complexity
     public func textColor(for highlightName: String) -> UIColor? {

--- a/Sources/Runestone/TextView/Core/LayoutManager.swift
+++ b/Sources/Runestone/TextView/Core/LayoutManager.swift
@@ -35,7 +35,7 @@ final class LayoutManager {
             }
         }
     }
-    var theme: Theme = DefaultTheme() {
+    var theme: Theme = DefaultTheme.share {
         didSet {
             if theme !== oldValue {
                 gutterBackgroundView.backgroundColor = theme.gutterBackgroundColor

--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -641,7 +641,7 @@ open class TextView: UIScrollView {
     /// Create a new text view.
     /// - Parameter frame: The frame rectangle of the text view.
     override public init(frame: CGRect) {
-        textInputView = TextInputView(theme: DefaultTheme())
+        textInputView = TextInputView(theme: DefaultTheme.share)
         super.init(frame: frame)
         backgroundColor = .white
         textInputView.delegate = self

--- a/Sources/Runestone/TextView/LineController/LineController.swift
+++ b/Sources/Runestone/TextView/LineController/LineController.swift
@@ -25,7 +25,7 @@ final class LineController {
             }
         }
     }
-    var theme: Theme = DefaultTheme() {
+    var theme: Theme = DefaultTheme.share {
         didSet {
             syntaxHighlighter?.theme = theme
             applyThemeToAllLineFragmentControllers()

--- a/Sources/Runestone/TextView/SyntaxHighlighting/Internal/PlainText/PlainTextSyntaxHighlighter.swift
+++ b/Sources/Runestone/TextView/SyntaxHighlighting/Internal/PlainText/PlainTextSyntaxHighlighter.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 
 final class PlainTextSyntaxHighlighter: LineSyntaxHighlighter {
-    var theme: Theme = DefaultTheme()
+    var theme: Theme = DefaultTheme.share
     var kern: CGFloat = 0
     var canHighlight: Bool {
         false

--- a/Sources/Runestone/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterSyntaxHighlighter.swift
+++ b/Sources/Runestone/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterSyntaxHighlighter.swift
@@ -15,7 +15,7 @@ enum TreeSitterSyntaxHighlighterError: LocalizedError {
 }
 
 final class TreeSitterSyntaxHighlighter: LineSyntaxHighlighter {
-    var theme: Theme = DefaultTheme()
+    var theme: Theme = DefaultTheme.share
     var kern: CGFloat = 0
     var canHighlight: Bool {
         languageMode.canHighlight


### PR DESCRIPTION
The `UIColor(named:in:compatibleWith:)` initializer method loads colors from the module's resource file on a global queue. Classes like `LineController` in the Runestone project create multiple instances of `DefaultTheme` during initialization, causing a large number of `UIColor` construction tasks to be allocated on the global queue. This can lead to noticeable lag, especially for larger texts, and prevent the editor from properly releasing memory when exiting.

The changes made in this pull request are as follows:
```swift
extension DefaultTheme {
    public static let share = DefaultTheme()
}
```
Then replace most occurrences of `DefaultTheme()` in the framework with `DefaultTheme.share`.