### PR TITLE
Fix issue when preparing text for insertion

### DIFF
--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -1320,12 +1320,8 @@ extension TextInputView {
 
     private func prepareTextForInsertion(_ text: String) -> String {
         // Ensure all line endings match our preferred line endings.
-        var preparedText = text
-        let lineEndingsToReplace: [LineEnding] = [.crlf, .cr, .lf].filter { $0 != lineEndings }
-        for lineEnding in lineEndingsToReplace {
-            preparedText = preparedText.replacingOccurrences(of: lineEnding.symbol, with: lineEndings.symbol)
-        }
-        return preparedText
+        let lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+        return lines.joined(separator: lineEndings.symbol)
     }
 }
 


### PR DESCRIPTION
When editor was set to CRLF line endings, and pasted text already contained CRLF endings, this function would not apply line ending changes correctly. Here we first split the text separating by any kind of new line character and then join them with the correct line ending.