### PR TITLE
Bump `TreeSitter` version to 0.25.6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tree-sitter/tree-sitter",
         "state": {
           "branch": null,
-          "revision": "98be227227af10cc7a269cb3ffb23686c0610b17",
-          "version": "0.20.9"
+          "revision": "bf655c0beaf4943573543fa77c58e8006ff34971",
+          "version": "0.25.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "Runestone", targets: ["Runestone"])
     ],
     dependencies: [
-        .package(url: "https://github.com/tree-sitter/tree-sitter", .upToNextMinor(from: "0.20.9"))
+        .package(url: "https://github.com/tree-sitter/tree-sitter", .upToNextMinor(from: "0.25.6"))
     ],
     targets: [
         .target(name: "Runestone", dependencies: [


### PR DESCRIPTION
Thank you for building this amazing library!

I'm using an abstraction over Runestone on iOS and visionOS and [CodeEditSourceEditor](https://github.com/CodeEditApp/CodeEditSourceEditor) on macOS on my app. CodeEditSourceEditor recently bumped their tree-sitter version to the latest release, causing dependency version mismatch headaches when using it together with Runestone in the same Xcode-managed Swift project. So the easiest way for me to fix my problem that didn't involve breaking things out into a separate package was to just bump Runestone's tree-sitter dependency, too.

Please let me know if this doesn't make sense to you to upstream at the moment and I'll keep it downstream. 🙂