### PR TITLE
Scroll edge effect blurs line numbers on iOS 26

### DIFF
--- a/Sources/Runestone/TextView/Core/TextView.swift
+++ b/Sources/Runestone/TextView/Core/TextView.swift
@@ -637,6 +637,20 @@ open class TextView: UIScrollView {
         let height = baseContentSize.height + verticalOverscrollLength
         return CGSize(width: width, height: height)
     }
+    @available(iOS 26.0, *)
+    private var scrollPocketView: UIView? {
+        if let _scrollPocketView = _scrollPocketView {
+            return _scrollPocketView
+        } else {
+            let stringType = String("IU_".reversed()) + "Scroll" + String("tekcoP".reversed())
+            let scrollPocketView = subviews.first { view in
+                String(describing: type(of: view)) == stringType
+            }
+            _scrollPocketView = scrollPocketView
+            return scrollPocketView
+        }
+    }
+    private var _scrollPocketView: UIView?
 
     /// Create a new text view.
     /// - Parameter frame: The frame rectangle of the text view.
@@ -674,6 +688,9 @@ open class TextView: UIScrollView {
         textInputView.frame = CGRect(x: 0, y: 0, width: max(contentSize.width, frame.width), height: max(contentSize.height, frame.height))
         textInputView.viewport = CGRect(origin: contentOffset, size: frame.size)
         bringSubviewToFront(textInputView.gutterContainerView)
+        if #available(iOS 26, *), let scrollPocketView {
+            bringSubviewToFront(scrollPocketView)
+        }
     }
 
     /// Called when the safe area of the view changes.


### PR DESCRIPTION
Ensures the new [UIScrollEdgeEffect](https://developer.apple.com/documentation/uikit/uiscrolledgeeffect) in iOS 26 blurs the line numbers by moving the line numbers below the _UIScrollPocket view.

https://github.com/user-attachments/assets/fdd5b99e-dcaf-4244-a56e-f3918423cb17

