### PR TITLE
TreeSitterQuery: pass utf8 byte count to ts_query_new

### DIFF
--- a/Sources/Runestone/TreeSitter/TreeSitterQuery.swift
+++ b/Sources/Runestone/TreeSitter/TreeSitterQuery.swift
@@ -21,7 +21,7 @@ final class TreeSitterQuery {
         let errorOffset = UnsafeMutablePointer<UInt32>.allocate(capacity: 1)
         let errorType = UnsafeMutablePointer<TSQueryError>.allocate(capacity: 1)
         let pointer = source.withCString { cstr in
-            ts_query_new(language, cstr, UInt32(source.count), errorOffset, errorType)
+            ts_query_new(language, cstr, UInt32(strlen(cstr)), errorOffset, errorType)
         }
         defer {
             errorOffset.deallocate()


### PR DESCRIPTION
Passing the Character count is problematic for query files that contain unicode characters (such as λ or ∀ -- as in [1]), because the Character count ends up being shorter than the byte length, leading to truncated patterns (as in the `@comment` at the end of [1]) or invalid syntax.

[1]: https://github.com/6cdh/tree-sitter-racket/blob/56b57807f86aa4ddb14892572b318edd4bc90ebe/queries/highlights.scm#L107