### PR TITLE
Fix missing selection change notifications for cut operations

### DIFF
--- a/Sources/Runestone/TextView/Core/TextInputView.swift
+++ b/Sources/Runestone/TextView/Core/TextInputView.swift
@@ -730,7 +730,9 @@ final class TextInputView: UIView, UITextInput {
     override func cut(_ sender: Any?) {
         if let selectedTextRange = selectedTextRange, let text = text(in: selectedTextRange) {
             UIPasteboard.general.string = text
+            inputDelegate?.selectionWillChange(self)
             replace(selectedTextRange, withText: "")
+            inputDelegate?.selectionDidChange(self)
         }
     }
 


### PR DESCRIPTION
  ## Summary

  `TextInputView.cut(_:)` did not notify `inputDelegate` when the selection
  changed after cutting text.

  Because of that, the visual selection highlight could remain visible even
  after the selected text had been removed and the selection had collapsed.

  ## Changes

  - call `selectionWillChange(_:)` before replacing the selected text during
  `cut(_:)`
  - call `selectionDidChange(_:)` after the replacement completes
  - align the `cut(_:)` behavior with the existing selection notification flow
  used by `paste(_:)`

  ## Testing

  - manually verify that cutting a selection removes the text and clears the
  visual selection highlight
  - confirm that the caret collapses to the expected insertion point after the
  cut operation

  ## Notes

  - this change is limited to selection notification handling in the cut path
  - no functional changes were made to copy, paste, or general text replacement
  behavior